### PR TITLE
Fixed Reference.isReference throws Exception with raw maps

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/map/reference/Reference.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/map/reference/Reference.java
@@ -156,7 +156,7 @@ public class Reference extends VABModelMap<Object> implements IReference {
 			return false;
 		}
 		
-		return ((Collection<Key>) map.get(KEY)).stream().allMatch(Key::isKey);
+		return ((Collection<?>) map.get(KEY)).stream().allMatch(Key::isKey);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/reference/TestReference.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/reference/TestReference.java
@@ -27,6 +27,7 @@ import org.eclipse.basyx.submodel.metamodel.map.qualifier.Identifiable;
 import org.eclipse.basyx.submodel.metamodel.map.qualifier.LangStrings;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Key;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Reference;
+import org.eclipse.basyx.vab.support.TypeDestroyer;
 import org.junit.Test;
 
 
@@ -95,9 +96,11 @@ public class TestReference {
 		Reference reference = new Reference(identifiable, KEY_ELEMENTS, IS_LOCAL);
 		
 		assertTrue(Reference.isReference(reference));
+		assertTrue(Reference.isReference(TypeDestroyer.destroyType(reference)));
 		
 		reference.put(Reference.KEY, "nonsense");
 		
 		assertFalse(Reference.isReference(reference));
+		assertFalse(Reference.isReference(TypeDestroyer.destroyType(reference)));
 	}
 }


### PR DESCRIPTION
Dear Mr. Frank,

I have fixed the bug "Fixed bug of Reference.isReference throws Exception when working with raw maps." and added corresponding test case for replicating this issue.

Thanks and Regards
Mohammad