### PR TITLE
Fixed getValue caching from org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/ConnectedSubmodelElement.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/ConnectedSubmodelElement.java
@@ -110,4 +110,9 @@ public abstract class ConnectedSubmodelElement extends ConnectedElement implemen
 	public SubmodelElement getLocalCopy() {
 		return SubmodelElement.createAsFacade(getElem()).getLocalCopy();
 	}
+
+	@Override
+	public Object getValue() {
+		return getProxy().getValue(MultiSubmodelElementProvider.VALUE);
+	}
 }

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedBlob.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedBlob.java
@@ -58,7 +58,7 @@ public class ConnectedBlob extends ConnectedDataElement implements IBlob {
 	public void setValue(String value) {
 		if (value instanceof String) {
 			// Assume a Base64 encoded String
-			setValue((Object) value);
+			super.setValue(value);
 		} else {
 			throw new IllegalArgumentException("Given Object is not a String");
 		}

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedDataElement.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedDataElement.java
@@ -30,11 +30,6 @@ public class ConnectedDataElement extends ConnectedSubmodelElement implements ID
 	protected KeyElements getKeyElement() {
 		return KeyElements.DATAELEMENT;
 	}
-	
-	@Override
-	public Object getValue() {
-		throw new UnsupportedOperationException("getValue is only possible in specific Element");
-	}
 
 	@Override
 	public DataElement getLocalCopy() {

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedFile.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedFile.java
@@ -28,7 +28,6 @@ public class ConnectedFile extends ConnectedDataElement implements IFile {
 
 	@Override
 	public String getValue() {
-		
 		// FIXME: This is a hack, fix this when API is clear
 		return (String) getProxy().getValue(Property.VALUE);
 	}
@@ -47,9 +46,9 @@ public class ConnectedFile extends ConnectedDataElement implements IFile {
 	public File getLocalCopy() {
 		return File.createAsFacade(getElem()).getLocalCopy();
 	}
-
+	
 	@Override
 	public void setValue(String value) {
-		setValue((Object) value);
+		super.setValue(value);
 	}
 }

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedMultiLanguageProperty.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedMultiLanguageProperty.java
@@ -11,7 +11,6 @@ package org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataeleme
 
 import java.util.Collection;
 import java.util.Map;
-
 import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
 import org.eclipse.basyx.submodel.metamodel.api.reference.enums.KeyElements;
 import org.eclipse.basyx.submodel.metamodel.api.submodelelement.dataelement.IMultiLanguageProperty;
@@ -31,10 +30,10 @@ public class ConnectedMultiLanguageProperty extends ConnectedDataElement impleme
 		super(proxy);
 	}
 
-	@Override
 	@SuppressWarnings("unchecked")
+	@Override
 	public LangStrings getValue() {
-		return LangStrings.createAsFacade((Collection<Map<String, Object>>) getElem().getPath(MultiLanguageProperty.VALUE));
+		return LangStrings.createAsFacade((Collection<Map<String, Object>>) super.getValue()) ;
 	}
 
 	@Override

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedProperty.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedProperty.java
@@ -63,11 +63,6 @@ public class ConnectedProperty extends ConnectedDataElement implements IProperty
 			return value;
 		}
 	}
-	
-	@Override
-	public void setValue(Object value) {
-		getProxy().setValue(Property.VALUE, ValueTypeHelper.prepareForSerialization(value));
-	}
 
 	@Override
 	public Property getLocalCopy() {

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedRange.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedRange.java
@@ -38,13 +38,13 @@ public class ConnectedRange extends ConnectedDataElement implements IRange {
 
 	@Override
 	public Object getMin() {
-		Object min = getElem().getPath(Range.MIN);
+		Object min = getElemLive().getPath(Range.MIN);
 		return ValueTypeHelper.getJavaObject(min, getValueType());
 	}
 
 	@Override
 	public Object getMax() {
-		Object max = getElem().getPath(Range.MAX);
+		Object max = getElemLive().getPath(Range.MAX);
 		return ValueTypeHelper.getJavaObject(max, getValueType());
 	}
 
@@ -84,7 +84,6 @@ public class ConnectedRange extends ConnectedDataElement implements IRange {
 				ValueTypeHelper.prepareForSerialization(maxRaw)
 			);
 				
-		
 		getProxy().setValue(MultiSubmodelElementProvider.VALUE, prepared);
 	}
 }

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedReferenceElement.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/dataelement/ConnectedReferenceElement.java
@@ -16,7 +16,6 @@ import org.eclipse.basyx.submodel.metamodel.api.reference.enums.KeyElements;
 import org.eclipse.basyx.submodel.metamodel.api.submodelelement.dataelement.IReferenceElement;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Reference;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.ReferenceElement;
-import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.Property;
 import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 
 /**
@@ -32,7 +31,7 @@ public class ConnectedReferenceElement extends ConnectedDataElement implements I
 	@SuppressWarnings("unchecked")
 	@Override
 	public IReference getValue() {
-		return Reference.createAsFacade((Map<String, Object>) getElem().getPath(Property.VALUE));
+		return Reference.createAsFacade((Map<String, Object>) super.getValue());
 	}
 	
 	@Override

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (C) 2021 the Eclipse BaSyx Authors
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement;
+
+import java.util.Map;
+import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
+import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
+import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
+import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+
+/**
+ * A helper class for SubmodelElement.
+ * 
+ * @author danish
+ *
+ */
+
+public class SubmodelElementTestHelper {
+	/**
+	 * Returns a stub for the provided propertyElement
+	 * 
+	 * @return 
+	 */
+	public static VABElementProxy createManager(Map<String, Object> propertyElement) {
+		VABConnectionManagerStub manager = new VABConnectionManagerStub(
+				new TypeDestroyingProvider(new SubmodelElementProvider(new VABLambdaProvider(propertyElement))));
+		
+		return manager.connectToVABElement("");
+	}
+	
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
@@ -29,7 +29,7 @@ public class SubmodelElementTestHelper {
 	 * 
 	 * @return 
 	 */
-	public static VABElementProxy createManager(Map<String, Object> propertyElement) {
+	public static VABElementProxy provideElementProxy(Map<String, Object> propertyElement) {
 		VABConnectionManagerStub manager = new VABConnectionManagerStub(
 				new TypeDestroyingProvider(new SubmodelElementProvider(new VABLambdaProvider(propertyElement))));
 		

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/SubmodelElementTestHelper.java
@@ -29,7 +29,7 @@ public class SubmodelElementTestHelper {
 	 * 
 	 * @return 
 	 */
-	public static VABElementProxy provideElementProxy(Map<String, Object> propertyElement) {
+	public static VABElementProxy createElementProxy(Map<String, Object> propertyElement) {
 		VABConnectionManagerStub manager = new VABConnectionManagerStub(
 				new TypeDestroyingProvider(new SubmodelElementProvider(new VABLambdaProvider(propertyElement))));
 		

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
@@ -11,16 +11,12 @@ package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.subm
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-
 import org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement.ConnectedBlob;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.Blob;
-import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
-import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
-import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
-import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+import org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.SubmodelElementTestHelper;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,18 +30,19 @@ public class TestConnectedBlob {
 	public final String BLOB_CONTENT = "BLOB_VALUE";
 
 	protected ConnectedBlob connectedBlob;
-	protected Blob blob;
+	protected Blob blob;	
 	
 	@Before
 	public void build() {
 		blob = new Blob("testIdShort", "mimeType");
+		
 		byte[] value = BLOB_CONTENT.getBytes(StandardCharsets.UTF_8);
+		
 		blob.setByteArrayValue(value);
 		
-		VABConnectionManagerStub manager = new VABConnectionManagerStub(
-				new SubmodelElementProvider(new TypeDestroyingProvider(new VABLambdaProvider(blob))));
+		VABElementProxy manager = SubmodelElementTestHelper.createManager(blob);
 
-		connectedBlob = new ConnectedBlob(manager.connectToVABElement(""));
+		connectedBlob = new ConnectedBlob(manager);
 	}
 	
 	/**
@@ -56,7 +53,6 @@ public class TestConnectedBlob {
 		assertEquals(blob.getValue(), connectedBlob.getValue());
 		byte[] byteArray = BLOB_CONTENT.getBytes(StandardCharsets.UTF_8);
 		assertEquals(Base64.getEncoder().encodeToString(byteArray), blob.getValue());
-
 	}
 
 	/**
@@ -114,5 +110,20 @@ public class TestConnectedBlob {
 		String newStringValue = Base64.getEncoder().encodeToString(newArrayValue);
 		connectedBlob.setValue(newStringValue);
 		assertEquals("NEW", connectedBlob.getUTF8String());
+	}
+	
+	@Test
+	public void setValueUpdatesValueCorrectly() {
+		triggerCachingOfSubmodelElement();
+
+		byte[] expected = BLOB_CONTENT.getBytes(StandardCharsets.US_ASCII);
+		
+		connectedBlob.setValue(Base64.getEncoder().encodeToString(expected));
+		
+		assertEquals(Base64.getEncoder().encodeToString(expected), connectedBlob.getValue());
+	}
+
+	private void triggerCachingOfSubmodelElement() {
+		connectedBlob.getElem();
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
@@ -40,9 +40,9 @@ public class TestConnectedBlob {
 		
 		blob.setByteArrayValue(value);
 		
-		VABElementProxy manager = SubmodelElementTestHelper.createManager(blob);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(blob);
 
-		connectedBlob = new ConnectedBlob(manager);
+		connectedBlob = new ConnectedBlob(elementProxy);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedBlob.java
@@ -40,7 +40,7 @@ public class TestConnectedBlob {
 		
 		blob.setByteArrayValue(value);
 		
-		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(blob);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.createElementProxy(blob);
 
 		connectedBlob = new ConnectedBlob(elementProxy);
 	}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
@@ -10,13 +10,10 @@
 package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.dataelement;
 
 import static org.junit.Assert.assertEquals;
-
 import org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement.ConnectedFile;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.File;
-import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
-import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
-import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
-import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+import org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.SubmodelElementTestHelper;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,10 +35,9 @@ public class TestConnectedFile {
 		file.setValue("FILE_VALUE");
 		file.setMimeType("mimeType");
 		
-		VABConnectionManagerStub manager = new VABConnectionManagerStub(
-				new SubmodelElementProvider(new TypeDestroyingProvider(new VABLambdaProvider(file))));
+		VABElementProxy manager = SubmodelElementTestHelper.createManager(file);
 
-		connectedFile = new ConnectedFile(manager.connectToVABElement(""));
+		connectedFile = new ConnectedFile(manager);
 	}
 	
 	/**
@@ -66,6 +62,21 @@ public class TestConnectedFile {
 		value += "TEST";
 		connectedFile.setValue(value);
 		assertEquals(value, connectedFile.getValue());
+	}
+	
+	@Test
+	public void setValueUpdatesValueCorrectly() {
+		triggerCachingOfSubmodelElement();
+
+		String expected = "Test File Value";
+		
+		connectedFile.setValue(expected);
+		
+		assertEquals(expected, connectedFile.getValue());
+	}
+
+	private void triggerCachingOfSubmodelElement() {
+		connectedFile.getElem();
 	}
 	
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
@@ -35,9 +35,9 @@ public class TestConnectedFile {
 		file.setValue("FILE_VALUE");
 		file.setMimeType("mimeType");
 		
-		VABElementProxy manager = SubmodelElementTestHelper.createManager(file);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(file);
 
-		connectedFile = new ConnectedFile(manager);
+		connectedFile = new ConnectedFile(elementProxy);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedFile.java
@@ -35,7 +35,7 @@ public class TestConnectedFile {
 		file.setValue("FILE_VALUE");
 		file.setMimeType("mimeType");
 		
-		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(file);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.createElementProxy(file);
 
 		connectedFile = new ConnectedFile(elementProxy);
 	}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
@@ -10,18 +10,11 @@
 package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.dataelement;
 
 import static org.junit.Assert.assertEquals;
-
-import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
-import org.eclipse.basyx.submodel.metamodel.api.reference.enums.KeyElements;
 import org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement.ConnectedMultiLanguageProperty;
 import org.eclipse.basyx.submodel.metamodel.map.qualifier.LangStrings;
-import org.eclipse.basyx.submodel.metamodel.map.reference.Key;
-import org.eclipse.basyx.submodel.metamodel.map.reference.Reference;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.MultiLanguageProperty;
-import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
-import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
-import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
-import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+import org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.SubmodelElementTestHelper;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,17 +31,15 @@ public class TestConnectedMultiLanguageProperty {
 	
 	@Before
 	public void build() {
-		
-		Reference ref = new Reference(new Key(KeyElements.BLOB, true, "", IdentifierType.CUSTOM));
 		LangStrings langStrings = new LangStrings("de", "TestBeschreibung");
 		
-		MLP = new MultiLanguageProperty(ref, langStrings);
+		MLP = new MultiLanguageProperty("idShort");
 		
-		VABConnectionManagerStub manager = new VABConnectionManagerStub(
-				new SubmodelElementProvider(new TypeDestroyingProvider(new VABLambdaProvider(MLP))));
+		MLP.setValue(langStrings);
+		
+		VABElementProxy manager = SubmodelElementTestHelper.createManager(MLP);
 
-		// Retrieve the ConnectedContainerProperty
-		connectedMLP = new ConnectedMultiLanguageProperty(manager.connectToVABElement(""));
+		connectedMLP = new ConnectedMultiLanguageProperty(manager);
 	}
 	
 	/**
@@ -65,5 +56,20 @@ public class TestConnectedMultiLanguageProperty {
 	@Test
 	public void testGetValueId() {
 		assertEquals(MLP.getValueId(), connectedMLP.getValueId());
+	}
+	
+	@Test
+	public void setValueUpdatesValueCorrectly() {
+		triggerCachingOfSubmodelElement();
+		
+		LangStrings expected = new LangStrings("en", "English Language");	
+
+		connectedMLP.setValue(expected);
+		
+		assertEquals(expected, connectedMLP.getValue());
+	}
+
+	private void triggerCachingOfSubmodelElement() {
+		connectedMLP.getElem();
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
@@ -37,7 +37,7 @@ public class TestConnectedMultiLanguageProperty {
 		
 		MLP.setValue(langStrings);
 		
-		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(MLP);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.createElementProxy(MLP);
 
 		connectedMLP = new ConnectedMultiLanguageProperty(elementProxy);
 	}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedMultiLanguageProperty.java
@@ -37,9 +37,9 @@ public class TestConnectedMultiLanguageProperty {
 		
 		MLP.setValue(langStrings);
 		
-		VABElementProxy manager = SubmodelElementTestHelper.createManager(MLP);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(MLP);
 
-		connectedMLP = new ConnectedMultiLanguageProperty(manager);
+		connectedMLP = new ConnectedMultiLanguageProperty(elementProxy);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
@@ -35,7 +35,7 @@ public class TestConnectedRange {
 		range = new Range(ValueType.Integer, new Integer(1), new Integer(10));
 		range.setIdShort("testIdShort");
 		
-		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(range);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.createElementProxy(range);
 
 		connectedRange = new ConnectedRange(elementProxy);
 	}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
@@ -35,9 +35,9 @@ public class TestConnectedRange {
 		range = new Range(ValueType.Integer, new Integer(1), new Integer(10));
 		range.setIdShort("testIdShort");
 		
-		VABElementProxy manager = SubmodelElementTestHelper.createManager(range);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(range);
 
-		connectedRange = new ConnectedRange(manager);
+		connectedRange = new ConnectedRange(elementProxy);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedRange.java
@@ -10,15 +10,12 @@
 package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.dataelement;
 
 import static org.junit.Assert.assertEquals;
-
 import org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement.ConnectedRange;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.valuetype.ValueType;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.range.Range;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.range.RangeValue;
-import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
-import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
-import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
-import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+import org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.SubmodelElementTestHelper;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,10 +34,10 @@ public class TestConnectedRange {
 	public void build() {
 		range = new Range(ValueType.Integer, new Integer(1), new Integer(10));
 		range.setIdShort("testIdShort");
-		VABConnectionManagerStub manager = new VABConnectionManagerStub(
-				new SubmodelElementProvider(new TypeDestroyingProvider(new VABLambdaProvider(range))));
+		
+		VABElementProxy manager = SubmodelElementTestHelper.createManager(range);
 
-		connectedRange = new ConnectedRange(manager.connectToVABElement(""));
+		connectedRange = new ConnectedRange(manager);
 	}
 	
 	/**
@@ -89,5 +86,20 @@ public class TestConnectedRange {
 		assertEquals(2, connectedRange.getMin());
 		assertEquals(8, connectedRange.getMax());
 		assertEquals(range.getValueType(), connectedRange.getValueType());
+	}
+	
+	@Test
+	public void setValueUpdatesValueCorrectly() {
+		triggerCachingOfSubmodelElement();
+
+		RangeValue expected = new RangeValue(10, 20);
+		
+		connectedRange.setValue(expected);
+		
+		assertEquals(expected, connectedRange.getValue());
+	}
+
+	private void triggerCachingOfSubmodelElement() {
+		connectedRange.getElem();
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
@@ -41,9 +41,9 @@ public class TestConnectedReferenceElement {
 		
 		refElem = new ReferenceElement(ref);
 		
-		VABElementProxy manager = SubmodelElementTestHelper.createManager(refElem);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(refElem);
 
-		connectedRefElem = new ConnectedReferenceElement(manager);
+		connectedRefElem = new ConnectedReferenceElement(elementProxy);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
@@ -12,15 +12,14 @@ package org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.subm
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
+import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
 import org.eclipse.basyx.submodel.metamodel.api.reference.enums.KeyElements;
 import org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement.ConnectedReferenceElement;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Key;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Reference;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.ReferenceElement;
-import org.eclipse.basyx.submodel.restapi.SubmodelElementProvider;
-import org.eclipse.basyx.testsuite.regression.vab.manager.VABConnectionManagerStub;
-import org.eclipse.basyx.vab.modelprovider.lambda.VABLambdaProvider;
-import org.eclipse.basyx.vab.support.TypeDestroyingProvider;
+import org.eclipse.basyx.testsuite.regression.submodel.metamodel.connected.submodelelement.SubmodelElementTestHelper;
+import org.eclipse.basyx.vab.modelprovider.VABElementProxy;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,10 +41,9 @@ public class TestConnectedReferenceElement {
 		
 		refElem = new ReferenceElement(ref);
 		
-		VABConnectionManagerStub manager = new VABConnectionManagerStub(
-				new SubmodelElementProvider(new TypeDestroyingProvider(new VABLambdaProvider(refElem))));
+		VABElementProxy manager = SubmodelElementTestHelper.createManager(refElem);
 
-		connectedRefElem = new ConnectedReferenceElement(manager.connectToVABElement(""));
+		connectedRefElem = new ConnectedReferenceElement(manager);
 	}
 	
 	/**
@@ -54,5 +52,20 @@ public class TestConnectedReferenceElement {
 	@Test
 	public void testGetValue() {
 		assertEquals(refElem.getValue(), connectedRefElem.getValue());
+	}
+
+	@Test
+	public void setValueUpdatesValueCorrectly() {
+		triggerCachingOfSubmodelElement();
+
+		IReference expected = new Reference(new Key(KeyElements.ASSET, true, "asset", IdentifierType.CUSTOM));
+
+		connectedRefElem.setValue(expected);
+		
+		assertEquals(expected, connectedRefElem.getValue());
+	}
+
+	private void triggerCachingOfSubmodelElement() {
+		connectedRefElem.getElem();
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/connected/submodelelement/dataelement/TestConnectedReferenceElement.java
@@ -41,7 +41,7 @@ public class TestConnectedReferenceElement {
 		
 		refElem = new ReferenceElement(ref);
 		
-		VABElementProxy elementProxy = SubmodelElementTestHelper.provideElementProxy(refElem);
+		VABElementProxy elementProxy = SubmodelElementTestHelper.createElementProxy(refElem);
 
 		connectedRefElem = new ConnectedReferenceElement(elementProxy);
 	}


### PR DESCRIPTION
Dear Mr. Frank

I have fixed the bug for "getValue caching from org.eclipse.basyx.submodel.metamodel.connected.submodelelement.dataelement" and added corresponding test cases for replicating this issue.

Thanks and Regards
Mohammad