### PR TITLE
Refactors DelegatedInvocationHelper to accept IConnectorFactory

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/restapi/operation/DelegatedInvocationManager.java
+++ b/src/main/java/org/eclipse/basyx/submodel/restapi/operation/DelegatedInvocationManager.java
@@ -17,15 +17,25 @@ import java.util.Map;
 import org.eclipse.basyx.submodel.metamodel.api.qualifier.qualifiable.IConstraint;
 import org.eclipse.basyx.submodel.metamodel.map.qualifier.qualifiable.Qualifier;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.operation.Operation;
-import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnectorFactory;
+import org.eclipse.basyx.vab.protocol.api.IConnectorFactory;
 
 /**
  * A helper class for operation invocation delegation
  * @author haque
  *
  */
-public class DelegatedInvocationHelper {
+public class DelegatedInvocationManager {
 	public static final String DELEGATION_TYPE = "invocationDelegation";
+	
+	private IConnectorFactory connectorFactory;
+	
+	/**
+	 * Constructs the DelegatedInvocationHelper using the passed connectorFactory for call delegation
+	 * @param connectorFactory IConnectorFactory to be used for delegation
+	 */
+	public DelegatedInvocationManager(IConnectorFactory connectorFactory) {
+		this.connectorFactory = connectorFactory;
+	}
 	
 	/**
 	 * Checks whether the given operation is delegated invocation
@@ -42,11 +52,20 @@ public class DelegatedInvocationHelper {
 	 * @param parameters
 	 * @return
 	 */
-	public static Object invokeDelegatedOperation(Operation operation, Object... parameters) {
+	public Object invokeDelegatedOperation(Operation operation, Object... parameters) {
 		String delegatedUrl = getDelegatedURL(operation);	
-		return new HTTPConnectorFactory()
+		return connectorFactory
 				.getConnector(delegatedUrl)
 				.invokeOperation("", parameters);
+	}
+	
+	/**
+	 * Creates the Qualifier used to tag an Operation as delegating operation
+	 * @param delegationURL the URL the Operation delegates to
+	 * @return the delegation Qualifier
+	 */
+	public static Qualifier createDelegationQualifier(String delegationURL) {
+		return new Qualifier(DelegatedInvocationManager.DELEGATION_TYPE, delegationURL, "string", null);
 	}
 	
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/OperationProviderTest.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/OperationProviderTest.java
@@ -28,7 +28,7 @@ import org.eclipse.basyx.submodel.metamodel.map.submodelelement.operation.Operat
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.operation.OperationVariable;
 import org.eclipse.basyx.submodel.restapi.OperationProvider;
 import org.eclipse.basyx.submodel.restapi.operation.CallbackResponse;
-import org.eclipse.basyx.submodel.restapi.operation.DelegatedInvocationHelper;
+import org.eclipse.basyx.submodel.restapi.operation.DelegatedInvocationManager;
 import org.eclipse.basyx.submodel.restapi.operation.InvocationRequest;
 import org.eclipse.basyx.submodel.restapi.operation.InvocationResponse;
 import org.eclipse.basyx.vab.exception.provider.MalformedRequestException;
@@ -256,7 +256,7 @@ public class OperationProviderTest {
 		Operation delegatedOperation = createOperation("delegatedOperation", null, null, null);
 		
 		// Create a delegated qualifier and add to the operation
-		Qualifier qualifier = new Qualifier(DelegatedInvocationHelper.DELEGATION_TYPE, API_INVOKE_URL, "string", null);
+		Qualifier qualifier = DelegatedInvocationManager.createDelegationQualifier(API_INVOKE_URL);
 		delegatedOperation.setQualifiers(Arrays.asList(qualifier));
 		
 		OperationProvider delegatedOpProvider = new OperationProvider(new VABLambdaProvider(delegatedOperation));


### PR DESCRIPTION
Refactors DelegatedInvocationHelper to be able to use custom IConnectorFactory for delegated invokations
Renames DelegatedInvocationHelper to DelegatedInvocationManager

Signed-off-by: Maximilian Conradi <maximilian.conradi@iese.fraunhofer.de>