### PR TITLE
Add authorized variant of ConnectedAssetAdministrationShellManager

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/authorization/AuthorizedAASAggregatorProxy.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/authorization/AuthorizedAASAggregatorProxy.java
@@ -11,8 +11,8 @@ package org.eclipse.basyx.extensions.aas.aggregator.authorization;
 
 import org.eclipse.basyx.aas.aggregator.proxy.AASAggregatorProxy;
 import org.eclipse.basyx.vab.coder.json.connector.JSONConnector;
-import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnector;
 import org.eclipse.basyx.vab.protocol.http.connector.IAuthorizationSupplier;
+import org.eclipse.basyx.vab.protocol.https.HTTPSConnector;
 
 /**
  * Local proxy class that hides HTTP calls to BaSys aggregator with enabled
@@ -32,7 +32,7 @@ public class AuthorizedAASAggregatorProxy extends AASAggregatorProxy {
 	 *            header
 	 */
 	public AuthorizedAASAggregatorProxy(String aasAggregatorUrl, IAuthorizationSupplier authorizationSupplier) {
-		super(new JSONConnector(new HTTPConnector(harmonizeURL(aasAggregatorUrl), authorizationSupplier)));
+		super(new JSONConnector(new HTTPSConnector(harmonizeURL(aasAggregatorUrl), authorizationSupplier)));
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/manager/authorized/AuthorizedConnectedAASManager.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/manager/authorized/AuthorizedConnectedAASManager.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (C) 2022 the Eclipse BaSyx Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.aas.manager.authorized;
+
+import org.eclipse.basyx.aas.manager.ConnectedAssetAdministrationShellManager;
+import org.eclipse.basyx.aas.registration.api.IAASRegistry;
+import org.eclipse.basyx.extensions.aas.registration.authorization.AuthorizedAASRegistryProxy;
+import org.eclipse.basyx.vab.protocol.http.connector.IAuthorizationSupplier;
+import org.eclipse.basyx.vab.protocol.https.HTTPSConnectorProvider;
+
+/**
+ * A ConnectedAASManager that uses a HTTPSConnector with authorization.
+ * Optionally, an authorized registry can also be created with an registry-URL
+ * 
+ * @author mueller-zhang, espen
+ */
+public class AuthorizedConnectedAASManager extends ConnectedAssetAdministrationShellManager {
+
+	/**
+	 * Constructor to create a ConnectedAASManager with an user defined registry and
+	 * authorization supplier
+	 * 
+	 * @param registry
+	 *            an user defined registry
+	 * @param authorizationSupplier
+	 *            Supplier for values to be placed in the HTTP Authorization request
+	 *            header
+	 */
+	public AuthorizedConnectedAASManager(IAASRegistry registry, IAuthorizationSupplier authorizationSupplier) {
+		super(registry, new HTTPSConnectorProvider(authorizationSupplier));
+	}
+
+	/**
+	 * Constructor to create a ConnectedAASManager with authorized registry and
+	 * authorization supplier
+	 * 
+	 * @param registryUrl
+	 *            registry url to create a registry with authorization
+	 * @param authorizationSupplier
+	 *            Supplier for values to be placed in the HTTP Authorization request
+	 *            header
+	 */
+	public AuthorizedConnectedAASManager(String registryUrl, IAuthorizationSupplier authorizationSupplier) {
+		super(new AuthorizedAASRegistryProxy(registryUrl, authorizationSupplier), new HTTPSConnectorProvider(authorizationSupplier));
+	}
+
+
+}

--- a/src/main/java/org/eclipse/basyx/extensions/aas/registration/authorization/AuthorizedAASRegistryProxy.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/registration/authorization/AuthorizedAASRegistryProxy.java
@@ -11,8 +11,8 @@ package org.eclipse.basyx.extensions.aas.registration.authorization;
 
 import org.eclipse.basyx.aas.registration.proxy.AASRegistryProxy;
 import org.eclipse.basyx.vab.coder.json.connector.JSONConnector;
-import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnector;
 import org.eclipse.basyx.vab.protocol.http.connector.IAuthorizationSupplier;
+import org.eclipse.basyx.vab.protocol.https.HTTPSConnector;
 
 /**
  * Local proxy class that hides HTTP calls to BaSys registry with enabled authorization.
@@ -28,7 +28,7 @@ public class AuthorizedAASRegistryProxy extends AASRegistryProxy {
 	 * @param authorizationSupplier Supplier for values to be placed in the HTTP Authorization request header
 	 */
 	public AuthorizedAASRegistryProxy(final String registryUrl, final IAuthorizationSupplier authorizationSupplier) {
-		super(new JSONConnector(new HTTPConnector(harmonizeURL(registryUrl), authorizationSupplier)));
+		super(new JSONConnector(new HTTPSConnector(harmonizeURL(registryUrl), authorizationSupplier)));
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/vab/protocol/https/HTTPSConnector.java
+++ b/src/main/java/org/eclipse/basyx/vab/protocol/https/HTTPSConnector.java
@@ -13,6 +13,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
 import org.eclipse.basyx.vab.protocol.http.connector.HTTPConnector;
+import org.eclipse.basyx.vab.protocol.http.connector.IAuthorizationSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,11 @@ public class HTTPSConnector extends HTTPConnector {
 		setHttpsClient();
 	}
 	
+	public HTTPSConnector(String address, IAuthorizationSupplier authorizationSupplier) {
+		super(address, authorizationSupplier);
+		setHttpsClient();
+	}
+
 	/**
 	 * Configures the client so that it can run with HTTPS protocol
 	 */

--- a/src/main/java/org/eclipse/basyx/vab/protocol/https/HTTPSConnectorProvider.java
+++ b/src/main/java/org/eclipse/basyx/vab/protocol/https/HTTPSConnectorProvider.java
@@ -12,6 +12,7 @@ package org.eclipse.basyx.vab.protocol.https;
 import org.eclipse.basyx.vab.coder.json.connector.JSONConnector;
 import org.eclipse.basyx.vab.modelprovider.api.IModelProvider;
 import org.eclipse.basyx.vab.protocol.api.ConnectorFactory;
+import org.eclipse.basyx.vab.protocol.http.connector.IAuthorizationSupplier;
 
 /**
  * An HTTPS Connector provider class
@@ -20,6 +21,21 @@ import org.eclipse.basyx.vab.protocol.api.ConnectorFactory;
  *
  */
 public class HTTPSConnectorProvider extends ConnectorFactory {
+	private IAuthorizationSupplier supplier;
+
+	public HTTPSConnectorProvider() {
+	}
+
+	/**
+	 * Constructor to create a HTTPSConenctorProvider with a given authorization
+	 * supplier
+	 * 
+	 * @param supplier
+	 *            given authorization supplier
+	 */
+	public HTTPSConnectorProvider(IAuthorizationSupplier supplier) {
+		this.supplier = supplier;
+	}
 
 	/**
 	 * returns HTTPSConnetor wrapped with ConnectedHashmapProvider that handles
@@ -27,6 +43,6 @@ public class HTTPSConnectorProvider extends ConnectorFactory {
 	 */
 	@Override
 	protected IModelProvider createProvider(String addr) {
-		return new JSONConnector(new HTTPSConnector(addr));
+		return new JSONConnector(new HTTPSConnector(addr, supplier));
 	}
 }


### PR DESCRIPTION
It uses HTTPSConnector and IAuthorizationSupplier per default

Co-authored-by: Daniel Espen <Daniel.Espen@iese.fraunhofer.de>
Signed-off-by: Zai Müller-Zhang <zai.mueller-zhang@iese.fraunhofer.de>