### PR TITLE
Refactored HasKind and fixing NullPointerException

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/api/qualifier/haskind/IHasKind.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/api/qualifier/haskind/IHasKind.java
@@ -16,5 +16,12 @@ package org.eclipse.basyx.submodel.metamodel.api.qualifier.haskind;
  *
 */
 public interface IHasKind {
+	public default ModelingKind getKind() {
+		return getModelingKind();
+	}
+	
+	/**
+	 * @deprecated Please use {@link #getKind()} instead.
+	 */
 	public ModelingKind getModelingKind();
 }

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/ConnectedSubmodel.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/ConnectedSubmodel.java
@@ -93,9 +93,15 @@ public class ConnectedSubmodel extends ConnectedElement implements ISubmodel {
 		return HasDataSpecification.createAsFacade(getElem()).getEmbeddedDataSpecifications();
 	}
 
+	
 	@Override
 	public ModelingKind getModelingKind() {
-		return HasKind.createAsFacade(getElem()).getModelingKind();
+		return this.getKind();
+	}
+
+	@Override
+	public ModelingKind getKind() {
+		return HasKind.createAsFacade(getElem()).getKind();
 	}
 
 	@Override

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/ConnectedSubmodelElement.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/ConnectedSubmodelElement.java
@@ -74,9 +74,18 @@ public abstract class ConnectedSubmodelElement extends ConnectedElement implemen
 		return HasSemantics.createAsFacade(getElem()).getSemanticId();
 	}
 
+	/**
+	 * @deprecated Please use {@link #getKind()} instead.
+	 */
 	@Override
 	public ModelingKind getModelingKind() {
-		return HasKind.createAsFacade(getElem()).getModelingKind();
+		return this.getKind();
+
+	}
+	
+	@Override
+	public ModelingKind getKind() {
+		return HasKind.createAsFacade(getElem()).getKind();
 
 	}
 

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/map/Submodel.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/map/Submodel.java
@@ -203,15 +203,30 @@ public class Submodel extends VABModelMap<Object> implements IElementContainer, 
 		HasDataSpecification.createAsFacade(this).setEmbeddedDataSpecifications(embeddedDataSpecifications);
 	}
 
+	/**
+	 * @deprecated Please use {@link #getKind()} instead.
+	 */
 	@Override
 	public ModelingKind getModelingKind() {
-		return HasKind.createAsFacade(this).getModelingKind();
+		return this.getKind();
 	}
 
+	/**
+	 * @deprecated Please use {@link #setKind(ModelingKind)} instead.
+	 */
 	public void setModelingKind(ModelingKind kind) {
-		HasKind.createAsFacade(this).setModelingKind(kind);
+		this.setKind(kind);
 	}
 
+	@Override
+	public ModelingKind getKind() {
+		return HasKind.createAsFacade(this).getKind();
+	}
+
+	public void setKind(ModelingKind kind) {
+		HasKind.createAsFacade(this).setKind(kind);
+	}
+	
 	@Override
 	public String getIdShort() {
 		return Referable.createAsFacade(this, getKeyElement()).getIdShort();

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/map/qualifier/haskind/HasKind.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/map/qualifier/haskind/HasKind.java
@@ -56,14 +56,33 @@ public class HasKind extends VABModelMap<Object> implements IHasKind {
 		return ret;
 	}
 
+	/**
+	 * @deprecated Please use {@link #getKind()} instead.
+	 */
 	@Override
 	public ModelingKind getModelingKind() {
+		return this.getKind();
+	}
+
+	/**
+	 * @deprecated Please use {@link #setKind(ModelingKind)} instead.
+	 */
+	public void setModelingKind(ModelingKind kind) {
+		this.setKind(kind);
+	}
+
+	@Override
+	public ModelingKind getKind() {
 		String str = (String) get(HasKind.KIND);
 		return ModelingKind.fromString(str);
 	}
 
-	public void setModelingKind(ModelingKind kind) {
-		put(HasKind.KIND, kind.toString());
+	public void setKind(ModelingKind kind) {
+		if (kind != null) {
+			put(HasKind.KIND, kind.toString());
+		} else {
+			put(HasKind.KIND, null);
+		}
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/map/submodelelement/SubmodelElement.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/map/submodelelement/SubmodelElement.java
@@ -163,13 +163,28 @@ public class SubmodelElement extends VABModelMap<Object> implements ISubmodelEle
 		HasSemantics.createAsFacade(this).setSemanticId(ref);
 	}
 
+	/**
+	 * @deprecated Please use {@link #getKind()} instead.
+	 */
 	@Override
 	public ModelingKind getModelingKind() {
-		return HasKind.createAsFacade(this).getModelingKind();
+		return this.getKind();
 	}
 
+	/**
+	 * @deprecated Please use {@link #setKind(ModelingKind)} instead.
+	 */
 	public void setModelingKind(ModelingKind kind) {
-		HasKind.createAsFacade(this).setModelingKind(kind);
+		this.setKind(kind);
+	}
+
+	@Override
+	public ModelingKind getKind() {
+		return HasKind.createAsFacade(this).getKind();
+	}
+
+	public void setKind(ModelingKind kind) {
+		HasKind.createAsFacade(this).setKind(kind);
 	}
 
 	@Override

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/qualifier/haskind/TestHasKind.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/qualifier/haskind/TestHasKind.java
@@ -10,6 +10,7 @@
 package org.eclipse.basyx.testsuite.regression.submodel.metamodel.map.qualifier.haskind;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.basyx.submodel.metamodel.api.qualifier.haskind.ModelingKind;
 import org.eclipse.basyx.submodel.metamodel.map.qualifier.haskind.HasKind;
@@ -35,13 +36,20 @@ public class TestHasKind {
 	
 	@Test
 	public void testConstructor() {
-		assertEquals(hasKind.getModelingKind(), MODELING_KIND); 
+		assertEquals(hasKind.getKind(), MODELING_KIND); 
 	}
 
 	@Test
 	public void testSetModelingKind() {
 		ModelingKind newModelingKind = ModelingKind.TEMPLATE;
-		hasKind.setModelingKind(newModelingKind);
-		assertEquals(newModelingKind, hasKind.getModelingKind());
+		hasKind.setKind(newModelingKind);
+		assertEquals(newModelingKind, hasKind.getKind());
+	}
+	
+	@Test
+	public void testSetModelingKindOfNull() {
+		// Explicitly set null
+		hasKind.setKind(null);
+		assertNull(hasKind.getKind());
 	}
 }


### PR DESCRIPTION
Refactored HasKind to be aligned with AAS Spec, where ModelingKind is held by attribute "kind" - not "modelingKind".
Additionally a NullPointerException is fixed, which occurs when kind is set to null 