### PR TITLE
Fixing NullPointerException on Property.setValueId(null)

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/map/submodelelement/dataelement/property/Property.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/map/submodelelement/dataelement/property/Property.java
@@ -157,9 +157,13 @@ public class Property extends DataElement implements IProperty {
 	}
 
 	public void setValueId(IReference ref) {
-		Reference refMap = new Reference();
-		refMap.setKeys(ref.getKeys());
-		put(Property.VALUEID, refMap);
+		if (ref != null) {
+			Reference refMap = new Reference();
+			refMap.setKeys(ref.getKeys());
+			put(Property.VALUEID, refMap);
+		} else {
+			put(Property.VALUEID, null);
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/submodelelement/dataelement/property/TestProperty.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/metamodel/map/submodelelement/dataelement/property/TestProperty.java
@@ -139,6 +139,9 @@ public class TestProperty {
 		IReference ref2 = new Reference(new Key(KeyElements.PROPERTY, true, "custom", IdentifierType.CUSTOM));
 		property.setValueId(ref);
 		assertEquals(ref2, property.getValueId());
+
+		property.setValueId(null);
+		assertNull(property.getValueId());
 	}
 
 	@Test


### PR DESCRIPTION
Property.valueId is optional - so setting it to null shouldn't result in a NullPointerException.