### PR TITLE
Fixes GitHub Action does not delete old packages

### DIFF
--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -31,7 +31,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Delete old sdk package
-      uses: actions/delete-package-versions@v1
+      uses: actions/delete-package-versions@v3
       continue-on-error: true
       with:
         package-name: 'org.eclipse.basyx.basyx.sdk'


### PR DESCRIPTION
Dear Frank,

Following was the issue with earlier version of delete-package-versions@v1 :
```
Run actions/delete-package-versions@v1
with:
package-name: org.eclipse.basyx.basyx.sdk
num-old-versions-to-delete: 1
token: ***
env:
JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64
Error: delete version mutation failed. Type mismatch on variable $packageVersionId and argument packageVersionId (String! / ID!)
```
This issue was found and fixed in v2. Issue link : #https://github.com/actions/delete-package-versions/issues/66#issuecomment-1055207022

Fixed by : #https://github.com/actions/delete-package-versions/pull/67

I have updated delete package version from v1 to v3 and this issue is not reproducible and old package is getting deleted.
Following is the log of successful deletion in my fork:
```
Run actions/delete-package-versions@v3
with:
package-name: org.eclipse.basyx.basyx.sdk
num-old-versions-to-delete: 1
min-versions-to-keep: -1
ignore-versions: ^$
delete-only-pre-release-versions: false
token: ***
env:
JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64
Total versions deleted till now: 1
```

Following is the link of successful run in my forked repository:
#https://github.com/mdanish98/basyx-java-sdk/runs/5646426371?check_suite_focus=true