### PR TITLE
Refactor MqttObservers to not add themselves

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIHelper.java
@@ -24,6 +24,8 @@
  ******************************************************************************/
 package org.eclipse.basyx.extensions.aas.api.mqtt;
 
+import org.eclipse.basyx.aas.restapi.observing.ObservableAASAPI;
+
 /**
  * A helper class containing string constants of topics used by the AASAPI.
  * 
@@ -33,4 +35,9 @@ package org.eclipse.basyx.extensions.aas.api.mqtt;
 public class MqttAASAPIHelper {
 	public static final String TOPIC_ADDSUBMODEL = "BaSyxAAS_addedSubmodelReference";
 	public static final String TOPIC_REMOVESUBMODEL = "BaSyxAAS_removedSubmodelReference";
+	
+	
+	public static String getAASIdShort(ObservableAASAPI observedAPI) {
+		return observedAPI.getAAS().getIdShort();
+	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIHelper.java
@@ -25,6 +25,7 @@
 package org.eclipse.basyx.extensions.aas.api.mqtt;
 
 import org.eclipse.basyx.aas.restapi.observing.ObservableAASAPI;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 
 /**
  * A helper class containing string constants of topics used by the AASAPI.
@@ -36,8 +37,15 @@ public class MqttAASAPIHelper {
 	public static final String TOPIC_ADDSUBMODEL = "BaSyxAAS_addedSubmodelReference";
 	public static final String TOPIC_REMOVESUBMODEL = "BaSyxAAS_removedSubmodelReference";
 	
-	
 	public static String getAASIdShort(ObservableAASAPI observedAPI) {
 		return observedAPI.getAAS().getIdShort();
+	}
+	
+	public static MqttConnectOptions getMqttConnectOptions(String username, char[] password) {
+		MqttConnectOptions options = new MqttConnectOptions();
+		options.setUserName(username);
+		options.setPassword(password);
+		
+		return options;
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
@@ -109,6 +109,8 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + brokerEndpoint);
+		
+		observedAPI.addObserver(this);
 	}
 
 	/**
@@ -135,6 +137,8 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this(clientId, MqttAASAPIHelper.getAASIdShort(observedAPI), user, pw, serverEndpoint, observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + serverEndpoint);
+		
+		observedAPI.addObserver(this);
 	}
 
 	/**
@@ -151,6 +155,8 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, MqttClient client) throws MqttException {
 		this(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+		
+		observedAPI.addObserver(this);
 	}
 	
 	private void connectMqttClientIfRequired() throws MqttException {

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
@@ -31,10 +31,12 @@ import org.eclipse.basyx.submodel.metamodel.api.reference.IKey;
 import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * Implementation of {@link IAASAPIObserver} Triggers MQTT events for different
@@ -54,33 +56,16 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * @param client
 	 *            An already connected mqtt client
 	 * @param aasIdShort
-	 * @param observedAPI
-	 *            The underlying aasAPI
+	 * @param username
+	 * 		  The Username as a String (can be null)
+	 * @param password
+	 * 		  A Char Array of the password (can be null)
 	 * @throws MqttException
 	 */
-	public MqttAASAPIObserver(MqttClient client, String aasIdShort, ObservableAASAPI observedAPI) throws MqttException {
+	public MqttAASAPIObserver(MqttClient client, String aasIdShort, @Nullable String username, @Nullable char[] password) throws MqttException {
 		super(client);
 		
-		connectMqttClientIfRequired();
-		
-		this.aasIdShort = aasIdShort;
-	}
-	
-	/**
-	 * Constructor for adding this MQTT extension on top of another aasAPI with
-	 * credentials
-	 * 
-	 * @param clientId
-	 * @param aasIdShort 
-	 * @param user 
-	 * @param password
-	 * @param serverEndpoint
-	 * @param observedAPI
-	 *            The underlying aasAPI
-	 * @throws MqttException
-	 */
-	public MqttAASAPIObserver(String clientId, String aasIdShort, String user, char[] password, String serverEndpoint, ObservableAASAPI observedAPI) throws MqttException {
-		super(serverEndpoint, clientId, user, password);
+		connectMqttClientIfRequired(username, password);
 		
 		this.aasIdShort = aasIdShort;
 	}
@@ -92,7 +77,7 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 *            The underlying aasAPI
 	 * @throws MqttException
 	 * 
-	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, String, char[])} instead.
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId) throws MqttException {
@@ -103,11 +88,11 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * Constructor for adding this MQTT extension on top of another AASAPI with a
 	 * custom persistence strategy
 	 * 
-	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, String, char[])} instead.
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
-		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttAASAPIHelper.getAASIdShort(observedAPI), null, null);
 		logger.info("Create new MQTT AASAPI for endpoint " + brokerEndpoint);
 		
 		observedAPI.addObserver(this);
@@ -120,7 +105,7 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 *            The underlying aasAPI
 	 * @throws MqttException
 	 * 
-	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(String, String, String, char[], String, ObservableAASAPI)} instead.
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, String, char[])} instead.
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw) throws MqttException {
@@ -131,11 +116,11 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * Constructor for adding this MQTT extension on top of another AASAPI with
 	 * credentials and persistency strategy
 	 * 
-	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(String, String, String, char[], String, ObservableAASAPI)} instead.
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, String, char[])} instead.
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
-		this(clientId, MqttAASAPIHelper.getAASIdShort(observedAPI), user, pw, serverEndpoint, observedAPI);
+		this(new MqttClient(serverEndpoint, clientId, persistence), MqttAASAPIHelper.getAASIdShort(observedAPI), user, pw);
 		logger.info("Create new MQTT AASAPI for endpoint " + serverEndpoint);
 		
 		observedAPI.addObserver(this);
@@ -150,19 +135,35 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 *            An already connected mqtt client
 	 * @throws MqttException
 	 * 
-	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, String, char[])} instead.
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, MqttClient client) throws MqttException {
-		this(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+		this(client, MqttAASAPIHelper.getAASIdShort(observedAPI), null, null);
 		
 		observedAPI.addObserver(this);
 	}
 	
-	private void connectMqttClientIfRequired() throws MqttException {
+	private void connectMqttClientIfRequired(String username, char[] password) throws MqttException {
 		if(!mqttClient.isConnected()) {
-			mqttClient.connect();
+			addOptionsAndConnectToMqttClientOrConnectWithoutOptions(username, password);
 		}
+	}
+
+	private void addOptionsAndConnectToMqttClientOrConnectWithoutOptions(String username, char[] password) throws MqttException {
+		if(!areCredentialsPresent(username, password)) {
+			mqttClient.connect();
+			return;
+		}
+		
+		MqttConnectOptions options = new MqttConnectOptions();
+		options.setUserName(username);
+		options.setPassword(password);
+		mqttClient.connect(options);
+	}
+
+	private boolean areCredentialsPresent(String username, char[] password) {
+		return username != null && password != null;
 	}
 
 	@Override

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
@@ -64,8 +64,6 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 		connectMqttClientIfRequired();
 		
 		this.aasIdShort = aasIdShort;
-		
-		observedAPI.addObserver(this);
 	}
 	
 	/**
@@ -85,8 +83,6 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 		super(serverEndpoint, clientId, user, password);
 		
 		this.aasIdShort = aasIdShort;
-		
-		observedAPI.addObserver(this);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
@@ -111,7 +111,7 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
-		this(new MqttClient(brokerEndpoint, clientId, persistence), getAASIdShort(observedAPI), observedAPI);
+		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + brokerEndpoint);
 	}
 
@@ -137,7 +137,7 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
-		this(clientId, getAASIdShort(observedAPI), user, pw, serverEndpoint, observedAPI);
+		this(clientId, MqttAASAPIHelper.getAASIdShort(observedAPI), user, pw, serverEndpoint, observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + serverEndpoint);
 	}
 
@@ -154,7 +154,7 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 */
 	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, MqttClient client) throws MqttException {
-		this(client, getAASIdShort(observedAPI), observedAPI);
+		this(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
 	}
 	
 	private void connectMqttClientIfRequired() throws MqttException {
@@ -180,10 +180,6 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 
 	public static String getCombinedMessage(String aasId, String idShort) {
 		return "(" + aasId + "," + idShort + ")";
-	}
-	
-	private static String getAASIdShort(ObservableAASAPI observedAPI) {
-		return observedAPI.getAAS().getIdShort();
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttAASAPIObserver.java
@@ -40,14 +40,54 @@ import org.slf4j.LoggerFactory;
  * Implementation of {@link IAASAPIObserver} Triggers MQTT events for different
  * operations on the AAS.
  * 
- * @author fried
+ * @author fried, danish
  *
  */
 public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObserver {
 	private static Logger logger = LoggerFactory.getLogger(MqttAASAPIObserver.class);
-
-	// The underlying AASAPI
-	protected ObservableAASAPI observedAPI;
+	
+	private String aasIdShort;
+	
+	/**
+	 * Constructor for adding this MQTT extension on top of another AASAPI
+	 * 
+	 * @param client
+	 *            An already connected mqtt client
+	 * @param aasIdShort
+	 * @param observedAPI
+	 *            The underlying aasAPI
+	 * @throws MqttException
+	 */
+	public MqttAASAPIObserver(MqttClient client, String aasIdShort, ObservableAASAPI observedAPI) throws MqttException {
+		super(client);
+		
+		connectMqttClientIfRequired();
+		
+		this.aasIdShort = aasIdShort;
+		
+		observedAPI.addObserver(this);
+	}
+	
+	/**
+	 * Constructor for adding this MQTT extension on top of another aasAPI with
+	 * credentials
+	 * 
+	 * @param clientId
+	 * @param aasIdShort 
+	 * @param user 
+	 * @param password
+	 * @param serverEndpoint
+	 * @param observedAPI
+	 *            The underlying aasAPI
+	 * @throws MqttException
+	 */
+	public MqttAASAPIObserver(String clientId, String aasIdShort, String user, char[] password, String serverEndpoint, ObservableAASAPI observedAPI) throws MqttException {
+		super(serverEndpoint, clientId, user, password);
+		
+		this.aasIdShort = aasIdShort;
+		
+		observedAPI.addObserver(this);
+	}
 
 	/**
 	 * Constructor for adding this MQTT extension on top of another AASAPI
@@ -55,7 +95,10 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * @param observedAPI
 	 *            The underlying aasAPI
 	 * @throws MqttException
+	 * 
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
 	 */
+	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId) throws MqttException {
 		this(observedAPI, serverEndpoint, clientId, new MqttDefaultFilePersistence());
 	}
@@ -63,12 +106,13 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	/**
 	 * Constructor for adding this MQTT extension on top of another AASAPI with a
 	 * custom persistence strategy
+	 * 
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
 	 */
+	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
-		super(brokerEndpoint, clientId, persistence);
+		this(new MqttClient(brokerEndpoint, clientId, persistence), getAASIdShort(observedAPI), observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + brokerEndpoint);
-		this.observedAPI = observedAPI;
-		observedAPI.addObserver(this);
 	}
 
 	/**
@@ -77,7 +121,10 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * @param observedAPI
 	 *            The underlying aasAPI
 	 * @throws MqttException
+	 * 
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(String, String, String, char[], String, ObservableAASAPI)} instead.
 	 */
+	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw) throws MqttException {
 		this(observedAPI, serverEndpoint, clientId, user, pw, new MqttDefaultFilePersistence());
 	}
@@ -85,12 +132,13 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	/**
 	 * Constructor for adding this MQTT extension on top of another AASAPI with
 	 * credentials and persistency strategy
+	 * 
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(String, String, String, char[], String, ObservableAASAPI)} instead.
 	 */
+	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
-		super(serverEndpoint, clientId, user, pw);
+		this(clientId, getAASIdShort(observedAPI), user, pw, serverEndpoint, observedAPI);
 		logger.info("Create new MQTT AASAPI for endpoint " + serverEndpoint);
-		this.observedAPI = observedAPI;
-		observedAPI.addObserver(this);
 	}
 
 	/**
@@ -101,11 +149,18 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 	 * @param client
 	 *            An already connected mqtt client
 	 * @throws MqttException
+	 * 
+	 * @deprecated This constructor is deprecated please use {@link #MqttAASAPIObserver(MqttClient, String, ObservableAASAPI)} instead.
 	 */
+	@Deprecated
 	public MqttAASAPIObserver(ObservableAASAPI observedAPI, MqttClient client) throws MqttException {
-		super(client);
-		this.observedAPI = observedAPI;
-		observedAPI.addObserver(this);
+		this(client, getAASIdShort(observedAPI), observedAPI);
+	}
+	
+	private void connectMqttClientIfRequired() throws MqttException {
+		if(!mqttClient.isConnected()) {
+			mqttClient.connect();
+		}
 	}
 
 	@Override
@@ -113,18 +168,22 @@ public class MqttAASAPIObserver extends MqttEventService implements IAASAPIObser
 		for (IKey key : submodelReference.getKeys()) {
 			if (key.getType().name().equalsIgnoreCase("Submodel")) {
 				String id = key.getValue();
-				sendMqttMessage(MqttAASAPIHelper.TOPIC_ADDSUBMODEL, getCombinedMessage(observedAPI.getAAS().getIdShort(), id));
+				sendMqttMessage(MqttAASAPIHelper.TOPIC_ADDSUBMODEL, getCombinedMessage(aasIdShort, id));
 			}
 		}
 	}
 
 	@Override
 	public void submodelRemoved(String id) {
-		sendMqttMessage(MqttAASAPIHelper.TOPIC_REMOVESUBMODEL, getCombinedMessage(observedAPI.getAAS().getIdShort(), id));
+		sendMqttMessage(MqttAASAPIHelper.TOPIC_REMOVESUBMODEL, getCombinedMessage(aasIdShort, id));
 	}
 
 	public static String getCombinedMessage(String aasId, String idShort) {
 		return "(" + aasId + "," + idShort + ")";
+	}
+	
+	private static String getAASIdShort(ObservableAASAPI observedAPI) {
+		return observedAPI.getAAS().getIdShort();
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	private IAASAPIFactory apiFactory;
 	private MqttClient client;
+	private MqttAASAPIObserver mqttAASAPIObserver;
 
 	public MqttDecoratingAASAPIFactory(IAASAPIFactory factoryToBeDecorated, MqttClient client) {
 		this.apiFactory = factoryToBeDecorated;
@@ -35,7 +36,8 @@ public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
 		try {
 			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.create(aas));
-			new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+			mqttAASAPIObserver = new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+			observedAPI.addObserver(mqttAASAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {
 			throw new ProviderException(e);

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
@@ -20,12 +20,11 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 /**
  * Factory decorating AASAPI with MQTT events by wrapping an IAASAPIFactory
  * 
- * @author fried
+ * @author fried, danish
  */
 public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	private IAASAPIFactory apiFactory;
 	private MqttClient client;
-	private MqttAASAPIObserver mqttAASAPIObserver;
 
 	public MqttDecoratingAASAPIFactory(IAASAPIFactory factoryToBeDecorated, MqttClient client) {
 		this.apiFactory = factoryToBeDecorated;
@@ -36,7 +35,7 @@ public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
 		try {
 			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.create(aas));
-			mqttAASAPIObserver = new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
+			MqttAASAPIObserver mqttAASAPIObserver = new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), null, null);
 			observedAPI.addObserver(mqttAASAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
@@ -35,7 +35,7 @@ public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
 		try {
 			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.create(aas));
-			MqttAASAPIObserver mqttAASAPIObserver = new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), null, null);
+			MqttAASAPIObserver mqttAASAPIObserver = new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI));
 			observedAPI.addObserver(mqttAASAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
@@ -35,7 +35,7 @@ public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
 		try {
 			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.create(aas));
-			new MqttAASAPIObserver(observedAPI, client);
+			new MqttAASAPIObserver(client, MqttAASAPIHelper.getAASIdShort(observedAPI), observedAPI);
 			return observedAPI;
 		} catch (MqttException e) {
 			throw new ProviderException(e);

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
@@ -41,6 +41,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	private ISubmodelAPIFactory apiFactory;
 	private MqttClient client;
+	private MqttSubmodelAPIObserver mqttSubmodelAPIObserver;
 
 	public MqttDecoratingSubmodelAPIFactory(ISubmodelAPIFactory factoryToBeDecorated, MqttClient client) {
 		this.apiFactory = factoryToBeDecorated;
@@ -51,7 +52,8 @@ public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
 		try {
 			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.create(submodel));
-			new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
+			mqttSubmodelAPIObserver = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
+			observedAPI.addObserver(mqttSubmodelAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {
 			throw new ProviderException(e);

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
@@ -36,12 +36,11 @@ import org.eclipse.paho.client.mqttv3.MqttException;
  * Factory decorating SubmodelAPI with MQTT events by wrapping an
  * ISubmodelAPIFactory
  * 
- * @author fried
+ * @author fried, danish
  */
 public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	private ISubmodelAPIFactory apiFactory;
 	private MqttClient client;
-	private MqttSubmodelAPIObserver mqttSubmodelAPIObserver;
 
 	public MqttDecoratingSubmodelAPIFactory(ISubmodelAPIFactory factoryToBeDecorated, MqttClient client) {
 		this.apiFactory = factoryToBeDecorated;
@@ -52,7 +51,7 @@ public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
 		try {
 			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.create(submodel));
-			mqttSubmodelAPIObserver = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
+			MqttSubmodelAPIObserver mqttSubmodelAPIObserver = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), null, null);
 			observedAPI.addObserver(mqttSubmodelAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
@@ -51,7 +51,7 @@ public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
 		try {
 			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.create(submodel));
-			new MqttSubmodelAPIObserver(observedAPI, client);
+			new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
 			return observedAPI;
 		} catch (MqttException e) {
 			throw new ProviderException(e);

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
@@ -51,7 +51,7 @@ public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
 		try {
 			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.create(submodel));
-			MqttSubmodelAPIObserver mqttSubmodelAPIObserver = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), null, null);
+			MqttSubmodelAPIObserver mqttSubmodelAPIObserver = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI));
 			observedAPI.addObserver(mqttSubmodelAPIObserver);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
@@ -44,7 +44,7 @@ import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
  * implementation of the ISubmodelAPI to forward its method calls.
  * 
  * 
- * @author espen
+ * @author espen, danish
  *
  * @deprecated Deprecated, please use {@link MqttDecoratingSubmodelAPIFactory}
  */
@@ -73,7 +73,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
+		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), null, null);
 		this.observedAPI.addObserver(observer);
 	}
 
@@ -93,7 +93,8 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(clientId, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw, serverEndpoint, this.observedAPI);
+		observer = new MqttSubmodelAPIObserver(new MqttClient(serverEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw);
+//		observer = new MqttSubmodelAPIObserver(clientId, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw, serverEndpoint);
 		this.observedAPI.addObserver(observer);
 	}
 
@@ -108,7 +109,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, MqttClient client) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
+		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), null, null);
 		this.observedAPI.addObserver(observer);
 	}
 

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
@@ -73,7 +73,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(this.observedAPI, brokerEndpoint, clientId, persistence);
+		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
 	}
 
 	/**
@@ -92,7 +92,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(this.observedAPI, serverEndpoint, clientId, user, pw, persistence);
+		observer = new MqttSubmodelAPIObserver(clientId, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw, serverEndpoint, this.observedAPI);
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, MqttClient client) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(this.observedAPI, client);
+		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
@@ -73,7 +73,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), null, null);
+		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI));
 		this.observedAPI.addObserver(observer);
 	}
 
@@ -93,8 +93,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(new MqttClient(serverEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw);
-//		observer = new MqttSubmodelAPIObserver(clientId, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw, serverEndpoint);
+		observer = new MqttSubmodelAPIObserver(new MqttClient(serverEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), MqttSubmodelAPIHelper.getMqttConnectOptions(user, pw));
 		this.observedAPI.addObserver(observer);
 	}
 
@@ -109,7 +108,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	 */
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, MqttClient client) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
-		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), null, null);
+		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI));
 		this.observedAPI.addObserver(observer);
 	}
 

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPI.java
@@ -74,6 +74,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
 		observer = new MqttSubmodelAPIObserver(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
+		this.observedAPI.addObserver(observer);
 	}
 
 	/**
@@ -93,6 +94,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
 		observer = new MqttSubmodelAPIObserver(clientId, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), user, pw, serverEndpoint, this.observedAPI);
+		this.observedAPI.addObserver(observer);
 	}
 
 	/**
@@ -107,6 +109,7 @@ public class MqttSubmodelAPI implements ISubmodelAPI {
 	public MqttSubmodelAPI(ISubmodelAPI observedAPI, MqttClient client) throws MqttException {
 		this.observedAPI = new ObservableSubmodelAPI(observedAPI);
 		observer = new MqttSubmodelAPIObserver(client, MqttSubmodelAPIHelper.getAASId(this.observedAPI), MqttSubmodelAPIHelper.getSubmodelId(this.observedAPI), this.observedAPI);
+		this.observedAPI.addObserver(observer);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
@@ -60,7 +60,7 @@ public class MqttSubmodelAPIHelper {
 				return createIdentifier(keys);
 			}
 		}
-		return null;
+		throw new RuntimeException("Could not find parent reference for the submodel '" + submodel.getIdShort() + "'");
 	}
 
 	private static boolean doesKeysExists(List<IKey> keys) {

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
@@ -33,6 +33,7 @@ import org.eclipse.basyx.submodel.metamodel.api.reference.IKey;
 import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
 import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
 import org.eclipse.basyx.submodel.restapi.observing.ObservableSubmodelAPI;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 
 /**
  * A helper class containing string constants of topics used by the SubmodelAPI.
@@ -69,5 +70,13 @@ public class MqttSubmodelAPIHelper {
 	
 	private static IIdentifier createIdentifier(List<IKey> keys) {
 		return new Identifier(IdentifierType.fromString(keys.get(0).getIdType().toString()), keys.get(0).getValue());
+	}
+	
+	public static MqttConnectOptions getMqttConnectOptions(String username, char[] password) {
+		MqttConnectOptions options = new MqttConnectOptions();
+		options.setUserName(username);
+		options.setPassword(password);
+		
+		return options;
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIHelper.java
@@ -24,6 +24,16 @@
  ******************************************************************************/
 package org.eclipse.basyx.extensions.submodel.mqtt;
 
+import java.util.List;
+
+import org.eclipse.basyx.submodel.metamodel.api.ISubmodel;
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
+import org.eclipse.basyx.submodel.metamodel.api.reference.IKey;
+import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
+import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
+import org.eclipse.basyx.submodel.restapi.observing.ObservableSubmodelAPI;
+
 /**
  * A helper class containing string constants of topics used by the SubmodelAPI.
  * 
@@ -35,4 +45,29 @@ public class MqttSubmodelAPIHelper {
 	public static final String TOPIC_ADDELEMENT = "BaSyxSubmodel_addedSubmodelElement";
 	public static final String TOPIC_DELETEELEMENT = "BaSyxSubmodel_removedSubmodelElement";
 	public static final String TOPIC_UPDATEELEMENT = "BaSyxSubmodel_updatedSubmodelElement";
+	
+	public static IIdentifier getSubmodelId(ObservableSubmodelAPI observedAPI) {
+		ISubmodel submodel = observedAPI.getSubmodel();
+		return submodel.getIdentification();
+	}
+	
+	public static IIdentifier getAASId(ObservableSubmodelAPI observedAPI) {
+		ISubmodel submodel = observedAPI.getSubmodel();
+		IReference parentReference = submodel.getParent();
+		if (parentReference != null) {
+			List<IKey> keys = parentReference.getKeys();
+			if (doesKeysExists(keys)) {
+				return createIdentifier(keys);
+			}
+		}
+		return null;
+	}
+
+	private static boolean doesKeysExists(List<IKey> keys) {
+		return keys != null && !keys.isEmpty();
+	}
+	
+	private static IIdentifier createIdentifier(List<IKey> keys) {
+		return new Identifier(IdentifierType.fromString(keys.get(0).getIdType().toString()), keys.get(0).getValue());
+	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
@@ -105,7 +105,6 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 		super(serverEndpoint, clientId, user, password);
 		
 		this.aasIdentifier = aasId;
-		
 		this.submodelIdentifier = submodelIdentifier;
 		
 		observedAPI.addObserver(this);

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
@@ -25,16 +25,10 @@
 package org.eclipse.basyx.extensions.submodel.mqtt;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.basyx.extensions.shared.mqtt.MqttEventService;
-import org.eclipse.basyx.submodel.metamodel.api.ISubmodel;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
-import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
-import org.eclipse.basyx.submodel.metamodel.api.reference.IKey;
-import org.eclipse.basyx.submodel.metamodel.api.reference.IReference;
-import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
 import org.eclipse.basyx.submodel.restapi.observing.ISubmodelAPIObserver;
 import org.eclipse.basyx.submodel.restapi.observing.ObservableSubmodelAPI;
 import org.eclipse.basyx.vab.modelprovider.VABPathTools;
@@ -134,7 +128,7 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	 */
 	@Deprecated
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
-		this(new MqttClient(brokerEndpoint, clientId, persistence), getAASId(observedAPI), getSubmodelId(observedAPI), observedAPI);
+		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
 		logger.info("Create new MQTT submodel for endpoint " + brokerEndpoint);
 	}
 
@@ -160,7 +154,7 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	 */
 	@Deprecated
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
-		this(clientId, getAASId(observedAPI), getSubmodelId(observedAPI), user, pw, serverEndpoint, observedAPI);
+		this(clientId, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), user, pw, serverEndpoint, observedAPI);
 		logger.info("Create new MQTT submodel for endpoint " + serverEndpoint);
 	}
 
@@ -177,7 +171,7 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	 */
 	@Deprecated
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, MqttClient client) throws MqttException {
-		this(client, getAASId(observedAPI), getSubmodelId(observedAPI), observedAPI);
+		this(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
 	}
 	
 	private void connectMqttClientIfRequired() throws MqttSecurityException, MqttException {
@@ -253,31 +247,6 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	private boolean filter(String idShort) {
 		idShort = VABPathTools.stripSlashes(idShort);
 		return !useWhitelist || whitelist.contains(idShort);
-	}
-	
-	private static IIdentifier getSubmodelId(ObservableSubmodelAPI observedAPI) {
-		ISubmodel submodel = observedAPI.getSubmodel();
-		return submodel.getIdentification();
-	}
-	
-	private static IIdentifier getAASId(ObservableSubmodelAPI observedAPI) {
-		ISubmodel submodel = observedAPI.getSubmodel();
-		IReference parentReference = submodel.getParent();
-		if (parentReference != null) {
-			List<IKey> keys = parentReference.getKeys();
-			if (doesKeysExists(keys)) {
-				return createIdentifier(IdentifierType.fromString(keys.get(0).getIdType().toString()), keys.get(0).getValue());
-			}
-		}
-		return null;
-	}
-
-	private static boolean doesKeysExists(List<IKey> keys) {
-		return keys != null && !keys.isEmpty();
-	}
-	
-	private static IIdentifier createIdentifier(IdentifierType idType, String id) {
-		return new Identifier(idType, id);
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
@@ -76,8 +76,6 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 		this.aasIdentifier = aasId;
 		this.submodelIdentifier = submodelIdentifier;
 		
-		observedAPI.addObserver(this);
-		
 		sendMqttMessage(MqttSubmodelAPIHelper.TOPIC_CREATESUBMODEL, this.submodelIdentifier.getId());
 	}
 	
@@ -100,8 +98,6 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 		
 		this.aasIdentifier = aasId;
 		this.submodelIdentifier = submodelIdentifier;
-		
-		observedAPI.addObserver(this);
 		
 		sendMqttMessage(MqttSubmodelAPIHelper.TOPIC_CREATESUBMODEL, this.submodelIdentifier.getId());
 	}

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
@@ -126,6 +126,10 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, String brokerEndpoint, String clientId, MqttClientPersistence persistence) throws MqttException {
 		this(new MqttClient(brokerEndpoint, clientId, persistence), MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
 		logger.info("Create new MQTT submodel for endpoint " + brokerEndpoint);
+		
+		observedAPI.addObserver(this);
+		
+		sendMqttMessage(MqttSubmodelAPIHelper.TOPIC_CREATESUBMODEL, this.submodelIdentifier.getId());
 	}
 
 	/**
@@ -152,6 +156,10 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, String serverEndpoint, String clientId, String user, char[] pw, MqttClientPersistence persistence) throws MqttException {
 		this(clientId, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), user, pw, serverEndpoint, observedAPI);
 		logger.info("Create new MQTT submodel for endpoint " + serverEndpoint);
+		
+		observedAPI.addObserver(this);
+		
+		sendMqttMessage(MqttSubmodelAPIHelper.TOPIC_CREATESUBMODEL, this.submodelIdentifier.getId());
 	}
 
 	/**
@@ -168,6 +176,10 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 	@Deprecated
 	public MqttSubmodelAPIObserver(ObservableSubmodelAPI observedAPI, MqttClient client) throws MqttException {
 		this(client, MqttSubmodelAPIHelper.getAASId(observedAPI), MqttSubmodelAPIHelper.getSubmodelId(observedAPI), observedAPI);
+		
+		observedAPI.addObserver(this);
+		
+		sendMqttMessage(MqttSubmodelAPIHelper.TOPIC_CREATESUBMODEL, this.submodelIdentifier.getId());
 	}
 	
 	private void connectMqttClientIfRequired() throws MqttSecurityException, MqttException {

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
@@ -43,7 +43,9 @@ import org.eclipse.basyx.submodel.restapi.observing.ObservableSubmodelAPI;
 import org.eclipse.basyx.submodel.restapi.vab.VABSubmodelAPI;
 import org.eclipse.basyx.testsuite.regression.extensions.shared.mqtt.MqttTestListener;
 import org.eclipse.basyx.vab.modelprovider.map.VABMapProvider;
+import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -88,7 +90,7 @@ public class MqttSubmodelAPIObserverTest {
 
 		VABSubmodelAPI vabAPI = new VABSubmodelAPI(new VABMapProvider(sm));
 		observableAPI = new ObservableSubmodelAPI(vabAPI);
-		new MqttSubmodelAPIObserver(observableAPI, "tcp://localhost:1884", "testClient");
+		new MqttSubmodelAPIObserver(new MqttClient("tcp://localhost:1884", "testClient", new MqttDefaultFilePersistence()), MqttSubmodelAPIHelper.getAASId(observableAPI) ,MqttSubmodelAPIHelper.getSubmodelId(observableAPI), observableAPI);
 	}
 
 	@AfterClass

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
@@ -61,7 +61,7 @@ import io.moquette.broker.config.ResourceLoaderConfig;
 /**
  * Test for MqttSubmodelAPIObserver
  * 
- * @author espen, conradi
+ * @author espen, conradi, danish
  *
  */
 public class MqttSubmodelAPIObserverTest {

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/submodel/mqtt/MqttSubmodelAPIObserverTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 
+import org.eclipse.basyx.extensions.submodel.mqtt.MqttDecoratingSubmodelAPIFactory;
 import org.eclipse.basyx.extensions.submodel.mqtt.MqttSubmodelAPIHelper;
 import org.eclipse.basyx.extensions.submodel.mqtt.MqttSubmodelAPIObserver;
 import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
@@ -39,10 +40,9 @@ import org.eclipse.basyx.submodel.metamodel.map.reference.Key;
 import org.eclipse.basyx.submodel.metamodel.map.reference.Reference;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.Property;
-import org.eclipse.basyx.submodel.restapi.observing.ObservableSubmodelAPI;
-import org.eclipse.basyx.submodel.restapi.vab.VABSubmodelAPI;
+import org.eclipse.basyx.submodel.restapi.api.ISubmodelAPI;
+import org.eclipse.basyx.submodel.restapi.vab.VABSubmodelAPIFactory;
 import org.eclipse.basyx.testsuite.regression.extensions.shared.mqtt.MqttTestListener;
-import org.eclipse.basyx.vab.modelprovider.map.VABMapProvider;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
@@ -65,12 +65,16 @@ import io.moquette.broker.config.ResourceLoaderConfig;
  *
  */
 public class MqttSubmodelAPIObserverTest {
+	private static final String CLIENT_ID = "testClient";
+	private static final String SERVER_URI = "tcp://localhost:1884";
 	private static final String AASID = "testaasid";
 	private static final String SUBMODELID = "testsubmodelid";
 
 	private static Server mqttBroker;
-	private static ObservableSubmodelAPI observableAPI;
+	private static ISubmodelAPI observableAPI;
 	private MqttTestListener listener;
+	
+	private static Submodel submodel;
 
 	/**
 	 * Sets up the MQTT broker and submodelAPI for tests
@@ -84,13 +88,15 @@ public class MqttSubmodelAPIObserverTest {
 		mqttBroker.startServer(classPathConfig);
 
 		// Create submodel
-		Submodel sm = new Submodel(SUBMODELID, new Identifier(IdentifierType.CUSTOM, SUBMODELID));
+		submodel = new Submodel(SUBMODELID, new Identifier(IdentifierType.CUSTOM, SUBMODELID));
 		Reference parentRef = new Reference(new Key(KeyElements.ASSETADMINISTRATIONSHELL, true, AASID, IdentifierType.IRDI));
-		sm.setParent(parentRef);
+		submodel.setParent(parentRef);
+		
+		observableAPI = createObservableSubmodelAPI();
+	}
 
-		VABSubmodelAPI vabAPI = new VABSubmodelAPI(new VABMapProvider(sm));
-		observableAPI = new ObservableSubmodelAPI(vabAPI);
-		new MqttSubmodelAPIObserver(new MqttClient("tcp://localhost:1884", "testClient", new MqttDefaultFilePersistence()), MqttSubmodelAPIHelper.getAASId(observableAPI) ,MqttSubmodelAPIHelper.getSubmodelId(observableAPI), observableAPI);
+	private static ISubmodelAPI createObservableSubmodelAPI() throws MqttException {
+		return new MqttDecoratingSubmodelAPIFactory(new VABSubmodelAPIFactory(), new MqttClient(SERVER_URI, CLIENT_ID, new MqttDefaultFilePersistence())).getSubmodelAPI(submodel);
 	}
 
 	@AfterClass


### PR DESCRIPTION
Description:

- Refactors MqttAASAPIObserver by adding two new constructors (1 additional due to credentials)
- Refactors MqttSubmodelAPIObserver by adding two new constructors (1 additional due to credentials)

Signed-off-by: Mohammad Ghazanfar Ali Danish ghazanfar.danish@iese.fraunhofer.de