### PR TITLE
Fix synchronous operation invocation

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/restapi/SubmodelProvider.java
+++ b/src/main/java/org/eclipse/basyx/submodel/restapi/SubmodelProvider.java
@@ -282,7 +282,7 @@ public class SubmodelProvider implements IModelProvider {
 	}
 
 	private Object invokeSync(String path, Object... parameters) {
-		String pathWithoutInvoke = path.replaceFirst(Pattern.quote(Operation.INVOKE), "");
+		String pathWithoutInvoke = path.substring(0, path.lastIndexOf(Operation.INVOKE));
 		String strippedPathWithoutInvoke = VABPathTools.stripSlashes(pathWithoutInvoke);
 		return submodelAPI.invokeOperation(strippedPathWithoutInvoke, parameters);
 	}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/SubmodelProviderTest.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/SubmodelProviderTest.java
@@ -534,6 +534,23 @@ public class SubmodelProviderTest {
 	}
 
 	@Test
+	public void testInvokeOperationWithExplicitSync() {
+		VABElementProxy submodelElement = getConnectionManager().connectToVABElement(submodelAddr);
+
+		// Wrap parameters before invoking add-operation
+		Map<String, Object> param1 = wrapParameter("FirstNumber", 5);
+		Map<String, Object> param2 = wrapParameter("SecondNumber", 2);
+
+		// Invoke operation with wrapped parameters and check result
+		Object result = submodelElement.invokeOperation(SMPROVIDER_PATH_PREFIX + "submodelElements/complex/invoke?async=false", param1, param2);
+		assertEquals(3, result);
+
+		// Invoke operation on parent element
+		result = submodelElement.invokeOperation(SMPROVIDER_PATH_PREFIX + "submodelElements/simple/invoke?async=false");
+		assertTrue((boolean) result);
+	}
+
+	@Test
 	public void testInvalidInvokePath() {
 		VABElementProxy smProxy = getConnectionManager().connectToVABElement(submodelAddr);
 		try {


### PR DESCRIPTION
Operation invocations used to fail with a `ResourceNotFound` exception when the query parameter `async` is explicitly set to `false`.
For example: `POST http://host/submodels/mySubmodel/submodel/submodelElements/myOperation/invoke?async=false`.

That's because `SubmodelProvider` deleted the first mention of `invoke` from the URL, leaving the `?async=false` behind.

This should work as expected now, making a synchronous request.