### PR TITLE
Fix  response object map to be used as invocation response in async operation

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/operation/ConnectedAsyncInvocation.java
+++ b/src/main/java/org/eclipse/basyx/submodel/metamodel/connected/submodelelement/operation/ConnectedAsyncInvocation.java
@@ -127,8 +127,8 @@ public class ConnectedAsyncInvocation implements IAsyncInvocation {
 		InvocationResponse response = null;
 		if (responseObj instanceof InvocationResponse) {
 			response = (InvocationResponse) responseObj;
-		} else if (result instanceof Map<?, ?>) {
-			response = InvocationResponse.createAsFacade((Map<String, Object>) result);
+		} else if (responseObj instanceof Map<?, ?>) {
+			response = InvocationResponse.createAsFacade((Map<String, Object>) responseObj);
 		} else {
 			// got no valid InvocationResponse
 			throw new ProviderException("Response for requestId " + requestId + " invalid!");


### PR DESCRIPTION
Fix  response object map to be used as invocation response in async operation

* It seems that "result" was used instead of "responseObj", but makes no sense here in my opinion.
* "result" map cannot be converted to invocation response.
* Instead changed to "responseObj" which can be a map if requested via rest call from remote submodel api.

Signed-off-by: Matthias Stöhr <matthias.stoehr@ipa.fraunhofer.de>