### PR TITLE
Change certain fields and methods of MapTaggedDirectory and TestRegis…

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/api/TaggedAASDescriptor.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/api/TaggedAASDescriptor.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.basyx.aas.metamodel.api.IAssetAdministrationShell;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.AASDescriptor;
@@ -112,8 +111,8 @@ public class TaggedAASDescriptor extends AASDescriptor {
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
-	public Set<String> getTags() {
-		return (Set<String>) get(TAGS);
+	public Collection<String> getTags() {
+		return (Collection<String>) get(TAGS);
 	}
 
 	@Override

--- a/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/map/MapTaggedDirectory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/map/MapTaggedDirectory.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.AASDescriptor;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.SubmodelDescriptor;
 import org.eclipse.basyx.aas.registration.memory.AASRegistry;
+import org.eclipse.basyx.aas.registration.memory.IRegistryHandler;
 import org.eclipse.basyx.aas.registration.memory.MapRegistryHandler;
 import org.eclipse.basyx.extensions.aas.directory.tagged.api.IAASTaggedDirectory;
 import org.eclipse.basyx.extensions.aas.directory.tagged.api.TaggedAASDescriptor;
@@ -34,7 +35,7 @@ import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
  *
  */
 public class MapTaggedDirectory extends AASRegistry implements IAASTaggedDirectory {
-	private Map<String, Set<TaggedAASDescriptor>> tagMap;
+	protected Map<String, Set<TaggedAASDescriptor>> tagMap;
 	private Map<String, Set<TaggedSubmodelDescriptor>> submodelTagMap = new LinkedHashMap<>();
 
 	private static final String WILDCARD = "*";
@@ -51,11 +52,16 @@ public class MapTaggedDirectory extends AASRegistry implements IAASTaggedDirecto
 		this.tagMap = tagMap;
 	}
 
+	public MapTaggedDirectory(IRegistryHandler registryHandler, Map<String, Set<TaggedAASDescriptor>> tagMap) {
+		super(registryHandler);
+		this.tagMap = tagMap;
+	}
+
 	@Override
 	public void register(TaggedAASDescriptor descriptor) {
 		// Let MapRegistry take care of the registry part and only manage the tags
 		super.register(descriptor);
-		addTags(descriptor.getTags(), descriptor);
+		addTags(descriptor);
 
 		Collection<SubmodelDescriptor> submodelDescriptors = descriptor.getSubmodelDescriptors();
 		for(SubmodelDescriptor smDesc : submodelDescriptors) {
@@ -73,7 +79,7 @@ public class MapTaggedDirectory extends AASRegistry implements IAASTaggedDirecto
 		addSubmodelTags(descriptor.getTags(), descriptor);
 	}
 
-	private void addSubmodelTags(Set<String> submodelTags, TaggedSubmodelDescriptor descriptor) {
+	protected void addSubmodelTags(Set<String> submodelTags, TaggedSubmodelDescriptor descriptor) {
 		submodelTags.stream().forEach(t -> addSubmodelTag(t, descriptor));
 	}
 
@@ -205,8 +211,8 @@ public class MapTaggedDirectory extends AASRegistry implements IAASTaggedDirecto
 		}
 	}
 
-	private void addTags(Set<String> tags, TaggedAASDescriptor descriptor) {
-		tags.stream().forEach(t -> addTag(t, descriptor));
+	protected void addTags(TaggedAASDescriptor descriptor) {
+		(descriptor.getTags()).stream().forEach(t -> addTag(t, descriptor));
 	}
 
 	private synchronized void addTag(String tag, TaggedAASDescriptor descriptor) {

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/directory/tagged/TestTaggedDirectorySuite.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/directory/tagged/TestTaggedDirectorySuite.java
@@ -99,7 +99,7 @@ public abstract class TestTaggedDirectorySuite extends TestRegistryProviderSuite
 	 * This method is not included in @Before to not interfere with test cases of
 	 * parent test suite, namely {@link TestRegistryProviderSuite#testGetMultiAAS()}
 	 */
-	private void init() {
+	protected void init() {
 		// Register AASs using several tags
 		TaggedAASDescriptor desc1 = new TaggedAASDescriptor(taggedAasIdShort1, taggedAAS1, taggedAasEndpoint1);
 		desc1.addTag(DEVICE);


### PR DESCRIPTION
…tryProviderSuite to implement MongoDBTaggedDirectory and its test. Change return type of TaggedAASDescriptor from Set to Collection, since mongoDB return tags as an ArrayList.

Signed-off-by: Zai Zhang <zai.mueller-zhang@iese.fraunhofer.de>
Co-authored-by: Daniel Espen <Daniel.Espen@iese.fraunhofer.de>