### PR TITLE
Change the type-checking of the AASDescriptor in the delete() method …

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/map/MapTaggedDirectory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/directory/tagged/map/MapTaggedDirectory.java
@@ -206,9 +206,13 @@ public class MapTaggedDirectory extends AASRegistry implements IAASTaggedDirecto
 		AASDescriptor desc = super.lookupAAS(aasIdentifier);
 		super.delete(aasIdentifier);
 
-		if (desc instanceof TaggedAASDescriptor) {
-			((TaggedAASDescriptor) desc).getTags().stream().forEach(t -> tagMap.get(t).remove(desc));
+		if (isTaggedAASDescriptor(desc)) {
+			TaggedAASDescriptor.createAsFacade(desc).getTags().stream().forEach(t -> tagMap.get(t).remove(desc));
 		}
+	}
+
+	private boolean isTaggedAASDescriptor(AASDescriptor desc) {
+		return desc.containsKey(TaggedAASDescriptor.TAGS);
 	}
 
 	protected void addTags(TaggedAASDescriptor descriptor) {


### PR DESCRIPTION
…due to the MongoDB backend.

With this change it would throw a casting error.

Signed-off-by: Zai Zhang <zai.mueller-zhang@iese.fraunhofer.de>