### PR TITLE
Configure health endpoint for AAS Registry and AAS Server

### DIFF
--- a/src/main/java/org/eclipse/basyx/vab/protocol/http/server/BaSyxHTTPServer.java
+++ b/src/main/java/org/eclipse/basyx/vab/protocol/http/server/BaSyxHTTPServer.java
@@ -41,8 +41,10 @@ import org.apache.catalina.LifecycleEvent;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Valve;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.valves.HealthCheckValve;
 import org.apache.tomcat.util.descriptor.web.FilterDef;
 import org.apache.tomcat.util.descriptor.web.FilterMap;
 import org.slf4j.Logger;
@@ -119,6 +121,8 @@ public class BaSyxHTTPServer {
 
 		tomcat.setHostname(context.hostname);
 		tomcat.getHost().setAppBase(".");
+		
+		configureHealthEndpoint();
 
 		// Create servlet context
 		// - Base path for resource files
@@ -133,6 +137,12 @@ public class BaSyxHTTPServer {
 		while (servletIterator.hasNext()) {
 			addNewServletAndMappingToTomcatEnvironment(context, rootCtx, servletIterator.next());
 		}
+	}
+
+	private void configureHealthEndpoint() {
+		Valve valve = new HealthCheckValve();
+		
+		tomcat.getHost().getPipeline().addValve(valve);
 	}
 
 	private void addNewServletAndMappingToTomcatEnvironment(BaSyxContext context, final Context rootCtx, Entry<String, HttpServlet> entry) {


### PR DESCRIPTION
[Feature Request]
https://github.com/eclipse-basyx/basyx-java-components/issues/124 

The health endpoint can be directly accessed by host/health.
For e.g if the AAS registry is hosted at http://localhost:4000 then the health endpoint would be http://localhost:4000/health

This endpoint will return 200 OK if everything is up and running.

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>