### PR TITLE
Refactor Commit "Externalize Mqtt payload to Helper classes"

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/mqtt/MqttAASAggregatorHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/mqtt/MqttAASAggregatorHelper.java
@@ -36,6 +36,14 @@ public class MqttAASAggregatorHelper {
 	public static final String TOPIC_DELETEAAS = "BaSyxAggregator_deletedAAS";
 	public static final String TOPIC_UPDATEAAS = "BaSyxAggregator_updatedAAS";
 
+	/***
+	 * Create payload for changed aas which includes creating, deleting, and
+	 * updating the corresponding aas.
+	 * 
+	 * @param aasId
+	 *            - the id of the changed aas
+	 * @return Mqtt-message payload
+	 */
 	public static String createAASChangedPayload(String aasId) {
 		return aasId;
 	}

--- a/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryHelper.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryHelper.java
@@ -24,6 +24,8 @@
  ******************************************************************************/
 package org.eclipse.basyx.extensions.aas.registration.mqtt;
 
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
+
 /**
  * A helper class containing method and string constants of topics used by the
  * AASRegistry.
@@ -44,8 +46,8 @@ public class MqttAASRegistryHelper {
 	 * @param aasId
 	 * @param smId
 	 */
-	public static String createSubmodelDescriptorOfAASChangedPayload(String aasId, String smId) {
-		return "(" + aasId + "," + smId + ")";
+	public static String createSubmodelDescriptorOfAASChangedPayload(IIdentifier aasId, IIdentifier smId) {
+		return "(" + aasId.getId() + "," + smId.getId() + ")";
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryService.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryService.java
@@ -113,7 +113,7 @@ public class MqttAASRegistryService extends MqttEventService implements IAASRegi
 	@Override
 	public void register(IIdentifier aas, SubmodelDescriptor smDescriptor) throws ProviderException {
 		this.observedRegistryService.register(aas, smDescriptor);
-		sendMqttMessage(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aas.getId(), smDescriptor.getIdentifier().getId()));
+		sendMqttMessage(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aas, smDescriptor.getIdentifier()));
 	}
 
 	@Override
@@ -125,7 +125,7 @@ public class MqttAASRegistryService extends MqttEventService implements IAASRegi
 	@Override
 	public void delete(IIdentifier aasId, IIdentifier smId) throws ProviderException {
 		this.observedRegistryService.delete(aasId, smId);
-		sendMqttMessage(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId.getId(), smId.getId()));
+		sendMqttMessage(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId, smId));
 	}
 
 	@Override

--- a/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryServiceObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/registration/mqtt/MqttAASRegistryServiceObserver.java
@@ -132,7 +132,7 @@ public class MqttAASRegistryServiceObserver extends MqttEventService implements 
 
 	@Override
 	public void submodelRegistered(IIdentifier aasId, IIdentifier smId) {
-		sendMqttMessage(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId.getId(), smId.getId()));
+		sendMqttMessage(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId, smId));
 	}
 
 	@Override
@@ -142,6 +142,6 @@ public class MqttAASRegistryServiceObserver extends MqttEventService implements 
 
 	@Override
 	public void submodelDeleted(IIdentifier aasId, IIdentifier smId) {
-		sendMqttMessage(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId.getId(), smId.getId()));
+		sendMqttMessage(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId, smId));
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttSubmodelAPIObserver.java
@@ -251,7 +251,19 @@ public class MqttSubmodelAPIObserver extends MqttEventService implements ISubmod
 		}
 	}
 
-
+	/**
+	 * This method will be removed from this class. MqttSubmodelAPIHelper is used to
+	 * create the payload.
+	 *
+	 * @deprecated Use
+	 *             {@link org.eclipse.basyx.extensions.submodel.mqtt.MqttSubmodelAPIHelper#createChangedSubmodelElementPayload(String, String, String)}
+	 *             instead.
+	 */
+	@Deprecated
+	public static String getCombinedMessage(String aasId, String submodelId, String elementPart) {
+		elementPart = VABPathTools.stripSlashes(elementPart);
+		return "(" + aasId + "," + submodelId + "," + elementPart + ")";
+	}
 
 	private boolean filter(String idShort) {
 		idShort = VABPathTools.stripSlashes(idShort);

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryService.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryService.java
@@ -138,7 +138,7 @@ public class TestMqttAASRegistryService {
 
 		eventAPI.register(AASIDENTIFIER, submodelDescriptor);
 
-		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER.getId(), newSubmodelIdentifier.getId()), listener.lastPayload);
+		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER, newSubmodelIdentifier), listener.lastPayload);
 		assertEquals(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, listener.lastTopic);
 	}
 
@@ -154,7 +154,7 @@ public class TestMqttAASRegistryService {
 	public void testDeleteSubmodel() {
 		eventAPI.delete(AASIDENTIFIER, SUBMODELIDENTIFIER);
 
-		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER.getId(), SUBMODELIDENTIFIER.getId()), listener.lastPayload);
+		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER, SUBMODELIDENTIFIER), listener.lastPayload);
 		assertEquals(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, listener.lastTopic);
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryServiceObserver.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryServiceObserver.java
@@ -142,7 +142,7 @@ public class TestMqttAASRegistryServiceObserver {
 
 		observedAPI.register(AASIDENTIFIER, submodelDescriptor);
 
-		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER.getId(), newSubmodelIdentifier.getId()), listener.lastPayload);
+		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER, newSubmodelIdentifier), listener.lastPayload);
 		assertEquals(MqttAASRegistryHelper.TOPIC_REGISTERSUBMODEL, listener.lastTopic);
 	}
 
@@ -158,7 +158,7 @@ public class TestMqttAASRegistryServiceObserver {
 	public void testDeleteSubmodel() {
 		observedAPI.delete(AASIDENTIFIER, SUBMODELIDENTIFIER);
 
-		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER.getId(), SUBMODELIDENTIFIER.getId()), listener.lastPayload);
+		assertEquals(MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AASIDENTIFIER, SUBMODELIDENTIFIER), listener.lastPayload);
 		assertEquals(MqttAASRegistryHelper.TOPIC_DELETESUBMODEL, listener.lastTopic);
 	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryServicePayloadParser.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/aas/registration/mqtt/TestMqttAASRegistryServicePayloadParser.java
@@ -11,8 +11,10 @@ package org.eclipse.basyx.testsuite.regression.extensions.aas.registration.mqtt;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.basyx.aas.metamodel.map.descriptor.CustomId;
 import org.eclipse.basyx.extensions.aas.registration.mqtt.MqttAASRegistryHelper;
 import org.eclipse.basyx.extensions.aas.registration.mqtt.MqttAASRegistryServicePayloadParser;
+import org.eclipse.basyx.submodel.metamodel.api.identifier.IIdentifier;
 import org.junit.Test;
 
 /**
@@ -24,6 +26,8 @@ import org.junit.Test;
 public class TestMqttAASRegistryServicePayloadParser {
 	private static final String AAS_ID = "aas001";
 	private static final String SUBMODEL_ID = "submodel001";
+	private static IIdentifier aasId = new CustomId(AAS_ID);
+	private static IIdentifier submodelId = new CustomId(SUBMODEL_ID);
 
 	@Test
 	public void registeredAASPayloadIsCorrectlyParsed() {
@@ -35,7 +39,7 @@ public class TestMqttAASRegistryServicePayloadParser {
 
 	@Test
 	public void registeredSubmodelPayloadIsCorrectlyParsed() {
-		String payload = MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(AAS_ID, SUBMODEL_ID);
+		String payload = MqttAASRegistryHelper.createSubmodelDescriptorOfAASChangedPayload(aasId, submodelId);
 
 		MqttAASRegistryServicePayloadParser parser = createPayloadParser(payload);
 		assertEquals(parser.extractShellId(), AAS_ID);


### PR DESCRIPTION
Add java doc to method in Mqtt*Helper.
Revert breaking change in createSubmodelDescriptorOfAASChangedPayload() in MqttAASRegistryHelper class. Mark getCombinedMessage() as deprecated.

Signed-off-by: Zai Zhang <zai.mueller-zhang@iese.fraunhofer.de>