### PR TITLE
Allows String representation for ValueTypes

### DIFF
--- a/src/main/java/org/eclipse/basyx/submodel/factory/xml/XMLHelper.java
+++ b/src/main/java/org/eclipse/basyx/submodel/factory/xml/XMLHelper.java
@@ -75,7 +75,15 @@ public class XMLHelper {
 	 * @return the given String or an empty String
 	 */
 	public static String getString(Object object) {
-		return object instanceof String ? ((String) object).trim() : "";
+		ValueType valueType;
+		try {
+			valueType = ValueTypeHelper.getType(object);
+		} catch (Exception ex) {
+			valueType = ValueType.None;
+		}
+		if (ValueType.None != valueType)
+			return object.toString().trim();
+		return "";
 	}
 
 	/**


### PR DESCRIPTION
During the serialization of Qualifiers (AASX), if there is a value of valueType different than String, the value won't be properly serialized. This leads to unexpected behaviour (most of the time exceptions) during deserialization.

Consider the follwing qualifier (Serialized with jackson):
```
{
    "@type": "Qualifier",
    "type": "NewType",
    "value": 123,
    "valueType": "int"
}
```

One would expect that the aasx file contains something like:

```
<aas:qualifier>
    <aas:valueId>
        <aas:keys/>
    </aas:valueId>
    <aas:value>123</aas:value>
    <aas:type>NewType</aas:type>
    <aas:valueType>int</aas:valueType>
</aas:qualifier>
```

But it is serialized like this instead

```
<aas:qualifier>
    <aas:valueId>
        <aas:keys/>
    </aas:valueId>
    <aas:value/>
    <aas:type>NewType</aas:type>
    <aas:valueType>int</aas:valueType>
</aas:qualifier>
```