### PR TITLE
Modifies AAS/SM deletion from registry in ConnectedAssetAdministrationShellManager

### DIFF
--- a/src/main/java/org/eclipse/basyx/aas/manager/ConnectedAssetAdministrationShellManager.java
+++ b/src/main/java/org/eclipse/basyx/aas/manager/ConnectedAssetAdministrationShellManager.java
@@ -145,7 +145,7 @@ public class ConnectedAssetAdministrationShellManager implements IAssetAdministr
 		proxyFactory.createProxy(addr).deleteValue("");
 
 		// Delete from Registry
-		deleteAasFromRegistryIfPresent(id);
+		deleteAasFromDirectoryIfPresent(id);
 
 		// TODO: How to handle submodels -> Lifecycle needs to be clarified
 	}
@@ -187,7 +187,7 @@ public class ConnectedAssetAdministrationShellManager implements IAssetAdministr
 		aasDirectory.register(new AASDescriptor(aas, combinedEndpoint));
 	}
 	
-	private void deleteAasFromRegistryIfPresent(IIdentifier aasId) {
+	private void deleteAasFromDirectoryIfPresent(IIdentifier aasId) {
 		try {
 			aasDirectory.delete(aasId);
 		} catch (ResourceNotFoundException e) {


### PR DESCRIPTION
In ConnectedAssetAdministrationShellManager, when deleting the AAS or SM it automatically tries to delete the corresponding AAS/SM from the registry as well, but if the AAS/SM has already been already removed from the registry then it would throw an exception. 

As the AAS server (v1.4.0) now unregisters the deleted AAS/SMs automatically from the registry, the deletion would throw an exception.

We observed this issue in basyx-examples, while upgrading the AAS-Server to 1.4.0.

This PR corrects the behavior.

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>