### PR TITLE
Updates poi-ooxml to latest version (v5.2.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,13 +263,20 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.1.2</version>
+			<version>5.2.3</version>
 		</dependency>
-		
+
+		<!-- Used by poi-ooxml -->
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-compress</artifactId>
-		    <version>1.23.0</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.20.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.23.0</version>
 		</dependency>
 		
 		<!-- Used by Logback to compile filter expressions from logback.xml -->

--- a/pom.xml
+++ b/pom.xml
@@ -266,13 +266,6 @@
 			<version>5.2.3</version>
 		</dependency>
 
-		<!-- Used by poi-ooxml -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.20.0</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>

--- a/src/main/java/org/eclipse/basyx/aas/factory/aasx/AASXToMetamodelConverter.java
+++ b/src/main/java/org/eclipse/basyx/aas/factory/aasx/AASXToMetamodelConverter.java
@@ -70,10 +70,24 @@ import org.xml.sax.SAXException;
  * 
  * The aas provides the references to the submodels and assets
  * 
+ * <p>
+ * The AASXToMetamodelConverter implements the AutoCloseable interface, indicating that it manages
+ * resources that need to be released after usage. To ensure proper resource cleanup,
+ * it is recommended to use one of the following approaches: <br>
+ * 
+ * 1. Try-with-resources <br>
+ * 2. Finally block <br>
+ * 3. Explicitly calling close {@link AASXToMetamodelConverter#close()}
+ * <br>
+ * Please choose the appropriate method based on your specific use case to ensure
+ * proper resource management and cleanup.
+ * 
+ * </p>
+ * 
  * @author zhangzai, conradi, danish
  *
  */
-public class AASXToMetamodelConverter {
+public class AASXToMetamodelConverter implements AutoCloseable {
 
 	private static final String XML_TYPE = "http://www.admin-shell.io/aasx/relationships/aas-spec";
 	private static final String AASX_ORIGIN = "/aasx/aasx-origin";
@@ -91,33 +105,27 @@ public class AASXToMetamodelConverter {
 
 	public AASXToMetamodelConverter(String path) {
 		this.aasxPath = path;
+		loadAASX();
 	}
 
 	public AASXToMetamodelConverter(InputStream stream) {
 		this.aasxInputStream = stream;
+		loadAASX();
 	}
 
 	public AasEnv retrieveAasEnv() throws ParserConfigurationException, SAXException, IOException, InvalidFormatException {
 		if (aasEnv != null) {
 			return aasEnv;
 		}
-
-		loadAASX();
-
+		
 		String xmlContent = getXMLResourceString(aasxRoot);
 		XMLToMetamodelConverter converter = new XMLToMetamodelConverter(xmlContent);
-		closeOPCPackage();
+		
 		return converter.parseAasEnv();
 	}
 	
-	public InputStream retrieveThumbnail() throws IOException, InvalidFormatException {
-		loadAASX();
-
-		InputStream thumbnailStream = getThumbnailStream(aasxRoot);
-		
-		closeOPCPackage();
-		
-		return thumbnailStream;
+	public InputStream retrieveThumbnail() throws IOException {
+		return getThumbnailStream(aasxRoot);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -128,36 +136,42 @@ public class AASXToMetamodelConverter {
 			return (Set<T>) bundles;
 		}
 
-		loadAASX();
-
 		AasEnv localAasEnv = retrieveAasEnv();
 
 		bundles = new AASBundleFactory().create(localAasEnv.getAssetAdministrationShells(), localAasEnv.getSubmodels(), localAasEnv.getAssets());
-
-		closeOPCPackage();
 
 		return (Set<T>) bundles;
 	}
 
 	public InputStream retrieveFileInputStream(String path) throws InvalidFormatException, IOException {
-		loadAASX();
 		PackagePart filePart = aasxRoot.getPart(PackagingURIHelper.createPartName(path));
-		closeOPCPackage();
+		
 		return filePart.getInputStream();
 	}
 
-	private void loadAASX() throws IOException, InvalidFormatException {
-		if (aasxInputStream == null) {
-			aasxInputStream = FileLoaderHelper.getInputStream(aasxPath);
+	/**
+	 * Closes the resources associated with the AASXToMetamodelConverter instance.
+	* After calling this method, the instance becomes unusable and subsequent method 
+	* invocations may result in undefined behavior.
+	* 
+	*/
+	@Override
+	public void close() {
+		try {
+			aasxRoot.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+			logger.error("Error clearing the resource OPCPackage");
 		}
-
-		if (aasxRoot == null) {
-			aasxRoot = OPCPackage.open(aasxInputStream);
+		
+		if (aasxInputStream != null) {
+			try {
+				aasxInputStream.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+				logger.error("Error clearing the resource InputStream");
+			}
 		}
-	}
-
-	private void closeOPCPackage() throws IOException {
-		aasxRoot.close();
 	}
 
 	/**
@@ -294,14 +308,12 @@ public class AASXToMetamodelConverter {
 	 * @throws URISyntaxException
 	 */
 	public void unzipRelatedFiles(Path pathToDirectory) throws InvalidFormatException, IOException, ParserConfigurationException, SAXException, URISyntaxException {
-	  loadAASX();
-	  
 	  List<String> files = parseReferencedFilePathsFromAASX();
+	  
 	  for (String filePath: files) {
 	    unzipFile(filePath, aasxRoot, pathToDirectory);
 	  }
 	  
-	  closeOPCPackage();
 	}
 
 	/**
@@ -370,5 +382,25 @@ public class AASXToMetamodelConverter {
 		String targetPath = destDir.toString() + "/" + VABPathTools.getLastElement(filePath);
 		InputStream stream = part.getInputStream();
 		FileUtils.copyInputStreamToFile(stream, new File(targetPath));
+	}
+	
+	private void loadAASX() {
+		if (aasxInputStream == null) {
+			try {
+				aasxInputStream = FileLoaderHelper.getInputStream(aasxPath);
+			} catch (IOException e) {
+				e.printStackTrace();
+				throw new RuntimeException("IO Exception occurred while getting input stream from path " + aasxPath);
+			}
+		}
+
+		if (aasxRoot == null) {
+			try {
+				aasxRoot = OPCPackage.open(aasxInputStream);
+			} catch (InvalidFormatException | IOException e) {
+				e.printStackTrace();
+				throw new RuntimeException("Exception occurred while opening the OPC Package " + aasxPath);
+			}
+		}
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/aasxupload/AASAggregatorAASXUpload.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/aasxupload/AASAggregatorAASXUpload.java
@@ -70,8 +70,7 @@ public class AASAggregatorAASXUpload implements IAASAggregatorAASXUpload {
 
 	@Override
 	public void uploadAASX(InputStream aasxStream) {
-		try {
-			AASXToMetamodelConverter converter = new AASXToMetamodelConverter(aasxStream);
+		try (AASXToMetamodelConverter converter = new AASXToMetamodelConverter(aasxStream)) {
 			Set<AASBundle> bundles = converter.retrieveAASBundles();
 			AASBundleHelper.integrate(this, bundles);
 			uploadFilesInAASX(converter);

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromBaSyx.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromBaSyx.java
@@ -133,7 +133,7 @@ public class TestAASXToMetamodelConverterFromBaSyx {
 	private int submodelSize;
 	private int submodelElementsSize;
 
-	private AASXToMetamodelConverter packageManager;
+	private static AASXToMetamodelConverter packageManager;
 
 	@Before
 	public void setup() throws IOException, TransformerException, ParserConfigurationException {
@@ -548,6 +548,8 @@ public class TestAASXToMetamodelConverterFromBaSyx {
 			new java.io.File(path).delete();
 		}
 		new java.io.File(CREATED_AASX_FILE_PATH).delete();
+		
+		packageManager.close();
 	}
 
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromBaSyx.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromBaSyx.java
@@ -71,6 +71,7 @@ import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.File
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.Property;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.valuetype.ValueType;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.operation.Operation;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -133,13 +134,18 @@ public class TestAASXToMetamodelConverterFromBaSyx {
 	private int submodelSize;
 	private int submodelElementsSize;
 
-	private static AASXToMetamodelConverter packageManager;
+	private AASXToMetamodelConverter packageManager;
 
 	@Before
 	public void setup() throws IOException, TransformerException, ParserConfigurationException {
 		createAASXFile(CREATED_AASX_FILE_PATH);
 
 		packageManager = new AASXToMetamodelConverter(CREATED_AASX_FILE_PATH);
+	}
+	
+	@After
+	public void close() {
+		packageManager.close();
 	}
 	
 	@Test
@@ -548,8 +554,6 @@ public class TestAASXToMetamodelConverterFromBaSyx {
 			new java.io.File(path).delete();
 		}
 		new java.io.File(CREATED_AASX_FILE_PATH).delete();
-		
-		packageManager.close();
 	}
 
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromFile.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestAASXToMetamodelConverterFromFile.java
@@ -50,6 +50,7 @@ import org.eclipse.basyx.submodel.metamodel.api.submodelelement.ISubmodelElement
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.Property;
 import org.eclipse.basyx.submodel.metamodel.map.submodelelement.dataelement.property.valuetype.ValueType;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.SAXException;
@@ -140,6 +141,11 @@ public class TestAASXToMetamodelConverterFromFile {
 		specificSubmodelOptional = getSpecificSubmodelAsOptional(submodelsFromConverter, EXPECTED_SUBMODEL_IDSHORT);
 		specificSubmodel = specificSubmodelOptional.get();
 		specificSubmodelElements = specificSubmodel.getSubmodelElements();
+	}
+	
+	@AfterClass
+	public static void tearDown() {
+		packageConverter.close();
 	}
 
 	/**

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestMetamodelToAASXConverter.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/aas/factory/aasx/TestMetamodelToAASXConverter.java
@@ -313,22 +313,21 @@ public class TestMetamodelToAASXConverter {
 	}
 
 	private Set<AASBundle> deserializeAASX(ByteArrayOutputStream byteStream) throws IOException, InvalidFormatException, ParserConfigurationException, SAXException {
-		AASXToMetamodelConverter aasxDeserializer = getDeserializedAASX(byteStream);
-		
-		return aasxDeserializer.retrieveAASBundles();
+		try (AASXToMetamodelConverter aasxDeserializer = getDeserializedAASX(byteStream)) {
+			return aasxDeserializer.retrieveAASBundles();
+		}
 	}
 	
 	private InputStream getThumbnailStreamFromAASX(ByteArrayOutputStream byteStream) throws IOException, InvalidFormatException, ParserConfigurationException, SAXException {
-		AASXToMetamodelConverter aasxDeserializer = getDeserializedAASX(byteStream);
-		
-		return aasxDeserializer.retrieveThumbnail();
+		try (AASXToMetamodelConverter aasxDeserializer = getDeserializedAASX(byteStream)) {
+			return aasxDeserializer.retrieveThumbnail();
+		}		
 	}
 
 	private AASXToMetamodelConverter getDeserializedAASX(ByteArrayOutputStream byteStream) {
 		InputStream in = new ByteArrayInputStream(byteStream.toByteArray());
 
-		AASXToMetamodelConverter aasxDeserializer = new AASXToMetamodelConverter(in);
-		return aasxDeserializer;
+		return new AASXToMetamodelConverter(in);
 	}
 
 	private void assertFilepathsAreCorrect(Set<AASBundle> aasBundles) {


### PR DESCRIPTION
- There have been many changes in poi-ooxml 5.x (https://poi.apache.org/changes.html)
- Some changes done related to closing of OPCPackage in poi-ooxml 5.x affecting basyx-java-sdk
- Adapts AASXToMetamodelConverter as per the changes in poi-ooxml 5.x
- Refactors test cases associated with the latest changes in AASXToMetamodelConverter i.e., releasing of resources.
- The changes in this PR is not a breaking change

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>