### PR TITLE
fixed file upload bug and corresponding test

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/aasxupload/AASAggregatorAASXUpload.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/aggregator/aasxupload/AASAggregatorAASXUpload.java
@@ -99,7 +99,7 @@ public class AASAggregatorAASXUpload implements IAASAggregatorAASXUpload {
 
 	private void uploadFileInSubmodelElement(IIdentifier aasIdentification, AASXToMetamodelConverter converter, File submodelElement, String submodelElementPath) {
 		try {
-			getAASProvider(aasIdentification).createValue(submodelElementPath + "/File/upload", converter.retrieveFileInputStream((String) submodelElement.getValue()));
+			getAASProvider(aasIdentification).createValue(submodelElementPath + "/upload", converter.retrieveFileInputStream((String) submodelElement.getValue()));
 		} catch (InvalidFormatException | IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/eclipse/basyx/submodel/restapi/SubmodelProvider.java
+++ b/src/main/java/org/eclipse/basyx/submodel/restapi/SubmodelProvider.java
@@ -349,7 +349,7 @@ public class SubmodelProvider implements IModelProvider {
 
 	private String getFileIdShortFromSplittedPath4FileUpload(String[] splitted) {
 		String idShort = "";
-		for (int i = 1; i < splitted.length - 2; i++) {
+		for (int i = 1; i < splitted.length - 1; i++) {
 			idShort = concatFileIdShortPath(splitted, idShort, i);
 		}
 		return idShort;

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/TestHttpFileUpload.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/submodel/restapi/TestHttpFileUpload.java
@@ -129,7 +129,7 @@ public class TestHttpFileUpload {
 		
 		HttpPost uploadFile = new HttpPost(
 				API_URL + "/basyx.examples.test/aas/submodels/test_sm/submodel/submodelElements/"
-						+ submodelElementIdShort + "/File/upload");
+						+ submodelElementIdShort + "/upload");
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 
 		builder.addPart("file", new FileBody(file));


### PR DESCRIPTION
The error was due to using the endpoint http://<server>:<port>/<contextPath>/shells/<aas-id>/.../<file-idShort>/upload now instead of http://<server>:<port>/<contextPath>/shells/<aas-id>/.../<file-idShort>/File/upload