### PR TITLE
Update AssetAdministrationShell.java

### DIFF
--- a/src/main/java/org/eclipse/basyx/aas/metamodel/map/AssetAdministrationShell.java
+++ b/src/main/java/org/eclipse/basyx/aas/metamodel/map/AssetAdministrationShell.java
@@ -228,6 +228,7 @@ public class AssetAdministrationShell extends VABModelMap<Object> implements IAs
 
 	public void setAsset(Asset asset) {
 		put(AssetAdministrationShell.ASSET, asset);
+		setAssetReference(asset.getReference());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -242,7 +243,7 @@ public class AssetAdministrationShell extends VABModelMap<Object> implements IAs
 		return Reference.createAsFacade((Map<String, Object>) get(ASSETREF));
 	}
 
-	public void setAssetReference(Reference ref) {
+	public void setAssetReference(IReference ref) {
 		put(ASSETREF, ref);
 	}
 


### PR DESCRIPTION
Setting an asset to an AAS sets also the asset ref

Adapted parameter type for setting asset ref (cause return type of getReference for an asset is IReference)