### PR TITLE
I4.0 extension based on BaSys4IPPS

### DIFF
--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/Message.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/Message.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain;
+
+/**
+ * Represents a I4.0 language message - VDI/VDE 2193. Please use either of the two subclasses, depending on if you want to publish a list of submodels or a list of key-value pairs. A message consists of a frame and interactionsElements.
+ *
+ * @author wand
+ */
+public abstract class Message {
+
+	private MessageFrame frame;
+
+	public MessageFrame getFrame() {
+		return frame;
+	}
+
+	public void setFrame(MessageFrame frame) {
+		this.frame = frame;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/MessageFrame.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/MessageFrame.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain;
+
+import org.eclipse.basyx.extensions.i4dot0.domain.message.frame.Participant;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.frame.SemanticProtocol;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Represents the frame of an I4.0 language message. All NotNull member variables are mandatory to create a valid I4.0 message.
+ *
+ * @author wand
+ */
+
+public class MessageFrame {
+
+	@NotNull
+	private String type;
+	private Participant sender;
+	private Participant receiver;
+	@NotNull
+	private String conversationId;
+	@NotNull
+	private Object messageId;
+	private String inReplyTo;
+	private String replyBy;
+	@NotNull
+	private SemanticProtocol semanticProtocol;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Participant getSender() {
+		return sender;
+	}
+
+	public void setSender(Participant sender) {
+		this.sender = sender;
+	}
+
+	public Participant getReceiver() {
+		return receiver;
+	}
+
+	public void setReceiver(Participant receiver) {
+		this.receiver = receiver;
+	}
+
+	public String getConversationId() {
+		return conversationId;
+	}
+
+	public void setConversationId(String conversationId) {
+		this.conversationId = conversationId;
+	}
+
+	public Object getMessageId() {
+		return messageId;
+	}
+
+	public void setMessageId(Object messageId) {
+		this.messageId = messageId;
+	}
+
+	public String getInReplyTo() {
+		return inReplyTo;
+	}
+
+	public void setInReplyTo(String inReplyTo) {
+		this.inReplyTo = inReplyTo;
+	}
+
+	public String getReplyBy() {
+		return replyBy;
+	}
+
+	public void setReplyBy(String replyBy) {
+		this.replyBy = replyBy;
+	}
+
+	public SemanticProtocol getSemanticProtocol() {
+		return semanticProtocol;
+	}
+
+	public void setSemanticProtocol(SemanticProtocol semanticProtocol) {
+		this.semanticProtocol = semanticProtocol;
+	}
+
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/GenericMessage.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/GenericMessage.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message;
+
+import org.eclipse.basyx.extensions.i4dot0.domain.Message;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This extension of {@link Message} is used to create a I4.0 message where the interactionElements are represented as List of key-value-pairs.
+ *
+ * @author wand
+ */
+public class GenericMessage extends Message {
+
+	private List<Map<String, Object>> interactionElements;
+
+	public List<Map<String, Object>> getInteractionElements() {
+		return interactionElements;
+	}
+
+	public void setInteractionElements(List<Map<String, Object>> interactionElements) {
+		this.interactionElements = interactionElements;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelElementCollectionMessage.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelElementCollectionMessage.java
@@ -22,22 +22,27 @@
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
-package org.eclipse.basyx.extensions.i4dot0.domain;
+package org.eclipse.basyx.extensions.i4dot0.domain.message;
+
+import org.eclipse.basyx.extensions.i4dot0.domain.Message;
+import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
+
+import java.util.List;
 
 /**
- * Represents a I4.0 language message - VDI/VDE 2193. Please use either of the subclasses, depending on if you want to publish a list of submodels or a list of key-value pairs. A message consists of a frame and interactionsElements.
+ * This extension of {@link Message} is used to create a I4.0 message where the interactionElements are represented as List of SubmodelElementCollections.
  *
  * @author wand
  */
-public abstract class Message {
+public class SubmodelElementCollectionMessage extends Message {
 
-	private MessageFrame frame;
+	private List<SubmodelElementCollection> interactionElements;
 
-	public MessageFrame getFrame() {
-		return frame;
+	public List<SubmodelElementCollection> getInteractionElements() {
+		return interactionElements;
 	}
 
-	public void setFrame(MessageFrame frame) {
-		this.frame = frame;
+	public void setInteractionElements(List<SubmodelElementCollection> interactionElements) {
+		this.interactionElements = interactionElements;
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelMessage.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelMessage.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message;
+
+import org.eclipse.basyx.extensions.i4dot0.domain.Message;
+import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
+
+import java.util.List;
+
+/**
+ * This extension of {@link Message} is used to create a I4.0 message where the interactionElements are represented as List of AAS submodels.
+ *
+ * @author wand
+ */
+public class SubmodelMessage extends Message {
+
+	private List<SubmodelElementCollection> interactionElements;
+
+	public List<SubmodelElementCollection> getInteractionElements() {
+		return interactionElements;
+	}
+
+	public void setInteractionElements(List<SubmodelElementCollection> interactionElements) {
+		this.interactionElements = interactionElements;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelMessage.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/SubmodelMessage.java
@@ -25,7 +25,7 @@
 package org.eclipse.basyx.extensions.i4dot0.domain.message;
 
 import org.eclipse.basyx.extensions.i4dot0.domain.Message;
-import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
+import org.eclipse.basyx.submodel.metamodel.map.Submodel;
 
 import java.util.List;
 
@@ -36,13 +36,13 @@ import java.util.List;
  */
 public class SubmodelMessage extends Message {
 
-	private List<SubmodelElementCollection> interactionElements;
+	private List<Submodel> interactionElements;
 
-	public List<SubmodelElementCollection> getInteractionElements() {
+	public List<Submodel> getInteractionElements() {
 		return interactionElements;
 	}
 
-	public void setInteractionElements(List<SubmodelElementCollection> interactionElements) {
+	public void setInteractionElements(List<Submodel> interactionElements) {
 		this.interactionElements = interactionElements;
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/Participant.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/Participant.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message.frame;
+
+/**
+ * Part of the I4.0 language message frame.
+ *
+ * @author wand
+ */
+public class Participant {
+
+	private ParticipantIdentification participantIdentification;
+	private ParticipantRole participantRole;
+
+	public ParticipantIdentification getIdentification() {
+		return participantIdentification;
+	}
+
+	public void setIdentification(ParticipantIdentification participantIdentification) {
+		this.participantIdentification = participantIdentification;
+	}
+
+	public ParticipantRole getRole() {
+		return participantRole;
+	}
+
+	public void setRole(ParticipantRole participantRole) {
+		this.participantRole = participantRole;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/ParticipantIdentification.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/ParticipantIdentification.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message.frame;
+
+/**
+ * Part of the I4.0 language message frame.
+ *
+ * @author wand
+ */
+public class ParticipantIdentification {
+
+	private String id;
+	private String idType;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getIdType() {
+		return idType;
+	}
+
+	public void setIdType(String idType) {
+		this.idType = idType;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/ParticipantRole.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/ParticipantRole.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message.frame;
+
+/**
+ * Part of the I4.0 language message frame.
+ *
+ * @author wand
+ */
+public class ParticipantRole {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/SemanticProtocol.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/SemanticProtocol.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message.frame;
+
+import java.util.List;
+
+/**
+ * Part of the I4.0 language message frame.
+ *
+ * @author wand
+ */
+public class SemanticProtocol {
+
+	private List<SemanticProtocolEntry> keys;
+
+	public List<SemanticProtocolEntry> getKeys() {
+		return keys;
+	}
+
+	public void setKeys(List<SemanticProtocolEntry> keys) {
+		this.keys = keys;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/SemanticProtocolEntry.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/domain/message/frame/SemanticProtocolEntry.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.domain.message.frame;
+
+/**
+ * Part of the I4.0 language message frame.
+ *
+ * @author wand
+ */
+public class SemanticProtocolEntry {
+
+	private String type;
+	private String idType;
+	private String value;
+	private Boolean local;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getIdType() {
+		return idType;
+	}
+
+	public void setIdType(String idType) {
+		this.idType = idType;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public void setValue(Boolean local) {
+		this.local = local;
+	}
+
+	public Boolean getLocal() {
+		return local;
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/CallbackExtender.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/CallbackExtender.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.mqtt;
+
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extends the default {@link MqttCallback} to provide debug logs for each callback method.
+ * <p>
+ * Implement this interface to handle incoming messages.
+ *
+ * @author wand
+ */
+public interface CallbackExtender extends MqttCallback {
+
+	Logger logger = LoggerFactory.getLogger(MqttConnector.class);
+
+	default void connectionLost(Throwable throwable) {
+		logger.error("MQTT lost connection: {}", Databus.getUri());
+	}
+
+	default void messageArrived(String s, MqttMessage mqttMessage) {
+		logger.debug("Received MQTT message | Payload - Endpoint | {} - {}", mqttMessage.getPayload(), Databus.getUri());
+	}
+
+	default void deliveryComplete(IMqttDeliveryToken iMqttDeliveryToken) {
+		logger.debug("Successfully delivered message | MessageId - Endpoint | {} - {}", iMqttDeliveryToken.getMessageId(), Databus.getUri());
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/Databus.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/Databus.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.mqtt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.basyx.extensions.i4dot0.domain.Message;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Used to set up a mqtt connection to a broker and publish I4.0-Language messages. Those messages need to be built as instance of {@link Message}.
+ *
+ * @author wand
+ */
+public class Databus {
+
+	private static final Logger logger = LoggerFactory.getLogger(Databus.class);
+	private static String uri;
+	private MqttConnector mqttConnector;
+
+	/**
+	 * Gets the connection uri
+	 *
+	 * @return The URI of the MQTT broker connector to
+	 */
+	public static String getUri() {
+		return uri;
+	}
+
+	/**
+	 * Sets the connection uri
+	 *
+	 * @param uri
+	 * 		URI of the MQTT broker.
+	 */
+	private static void setUri(String uri) {
+		Databus.uri = uri;
+	}
+
+	/**
+	 * Provide the following parameter to set up a mqtt connection to a broker. This client is set up specifically to handle I4.0 communication.
+	 *
+	 * @param serverUri
+	 * 		The URI of the MQTT broker.
+	 * @param subTopic
+	 * 		The topic from which the messages are received.
+	 * @param pubTopic
+	 * 		The topic on which messages are published.
+	 * @param user
+	 * 		Pass the username of the mqtt broker if it uses authentication, otherwise null
+	 * @param pw
+	 * 		Pass the password of the mqtt broker if it uses authentication, otherwise null
+	 * @return MqttClient to be able to override the callback if needed.
+	 */
+	public MqttClient init(String serverUri, String subTopic, String pubTopic, String user, char[] pw) {
+		setUri(serverUri);
+		mqttConnector = new MqttConnector();
+		mqttConnector.connect(serverUri, subTopic, pubTopic, user, pw);
+		return mqttConnector.getClient();
+	}
+
+	/**
+	 * Use this method to publish I4.0 messages.
+	 *
+	 * @param message
+	 * 		The message to be published. Should be an extension of the class {@link Message}.
+	 */
+	public void publish(Message message) {
+		MqttMessage mqttMessage = new MqttMessage();
+		ObjectMapper mapper = new ObjectMapper();
+		mqttMessage.setQos(1);
+		mqttMessage.setRetained(false);
+		try {
+			mqttMessage.setPayload(mapper.writeValueAsBytes(message));
+		} catch (JsonProcessingException e) {
+			logger.error("Unable to serialize I4.0 message!");
+		}
+		mqttConnector.publish(mqttMessage);
+	}
+}

--- a/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/MqttConnector.java
+++ b/src/main/java/org/eclipse/basyx/extensions/i4dot0/mqtt/MqttConnector.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.extensions.i4dot0.mqtt;
+
+import org.eclipse.basyx.extensions.aas.api.mqtt.MqttAASAPIHelper;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * Set up the mqtt connection to a broker. It is also used to publish the mqtt messages. All information is provided by the {@link Databus}.
+ *
+ * @author wand
+ */
+public class MqttConnector implements CallbackExtender {
+
+	private static final Logger logger = LoggerFactory.getLogger(MqttConnector.class);
+	private MqttClient client;
+	private String pubTopic;
+
+	protected void connect(String serverUri, String subTopic, String pubTopic, String user, char[] pw) {
+		this.pubTopic = pubTopic;
+		try (MemoryPersistence persistence = new MemoryPersistence()) {
+			client = new MqttClient(serverUri, UUID.randomUUID().toString(), persistence);
+			if (user != null && pw != null) {
+				MqttConnectOptions options = MqttAASAPIHelper.getMqttConnectOptions(user, pw);
+				client.connect(options);
+			} else {
+				client.connect();
+			}
+			client.setCallback(this);
+			client.subscribe(subTopic);
+		} catch (MqttException e) {
+			logger.error("MQTT connection couldn't be established - {}", e.getMessage());
+		}
+	}
+
+	protected void publish(MqttMessage message) {
+		try {
+			client.publish(pubTopic, message);
+		} catch (MqttException e) {
+			logger.error("Couldn't publish message - {}", message.getId());
+		}
+	}
+
+	protected MqttClient getClient() {
+		return client;
+	}
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/MessageHelper.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/MessageHelper.java
@@ -1,2 +1,125 @@
-package org.eclipse.basyx.testsuite.regression.extensions.i4dot0;public class MessageHelper {
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0;
+
+import org.eclipse.basyx.extensions.i4dot0.domain.MessageFrame;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.GenericMessage;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.SubmodelElementCollectionMessage;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.SubmodelMessage;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.frame.*;
+import org.eclipse.basyx.submodel.metamodel.map.Submodel;
+import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
+
+import java.util.*;
+
+/**
+ * Helper class to generate an instance of each subclass of {@link org.eclipse.basyx.extensions.i4dot0.domain.Message}. Shows example usage for each message type, as well as the usage of the {@link MessageFrame}.
+ *
+ * @author wand
+ */
+public class MessageHelper {
+
+	private final List<Submodel> submodelList;
+
+	public MessageHelper(List<Submodel> submodelList) {
+		this.submodelList = submodelList;
+	}
+
+	public GenericMessage generateGenericMessage() {
+		GenericMessage genericMessage = new GenericMessage();
+		genericMessage.setFrame(generateMessageFrame());
+
+		Map<String, Object> interactionElements = new HashMap<>();
+		interactionElements.put("interactionElement1", "Bob");
+		interactionElements.put("interactionElement2", "Eve");
+		genericMessage.setInteractionElements(List.of(interactionElements));
+
+		return genericMessage;
+	}
+
+	public SubmodelMessage generateSubmodelMessage() {
+		SubmodelMessage submodelMessage = new SubmodelMessage();
+		submodelMessage.setFrame(generateMessageFrame());
+
+		submodelMessage.setInteractionElements(List.of(submodelList.get(0)));
+		return submodelMessage;
+	}
+
+	public SubmodelElementCollectionMessage generateSubmodelElementCollectionMessage() {
+		SubmodelElementCollectionMessage smcMessage = new SubmodelElementCollectionMessage();
+		smcMessage.setFrame(generateMessageFrame());
+		smcMessage.setInteractionElements(List.of((SubmodelElementCollection) submodelList.get(1).getSubmodelElement("OperatingManual")));
+		return smcMessage;
+	}
+
+	private MessageFrame generateMessageFrame() {
+		MessageFrame frame = new MessageFrame();
+		frame.setMessageId(0);
+		frame.setConversationId(UUID.randomUUID().toString());
+
+		Participant receiver = new Participant();
+		ParticipantIdentification receiverIdentification = new ParticipantIdentification();
+		ParticipantRole receiverRole = new ParticipantRole();
+
+		receiverIdentification.setId("TEST_RECEIVER");
+		receiverIdentification.setIdType("CUSTOM");
+		receiverRole.setName("InformationReceiver");
+
+		receiver.setIdentification(receiverIdentification);
+		receiver.setRole(receiverRole);
+
+		frame.setReceiver(receiver);
+
+		Participant sender = new Participant();
+		ParticipantIdentification senderIdentification = new ParticipantIdentification();
+		ParticipantRole senderRole = new ParticipantRole();
+
+		senderIdentification.setId("TEST_SENDER");
+		senderIdentification.setIdType("CUSTOM");
+		senderRole.setName("InformationSender");
+
+		sender.setIdentification(senderIdentification);
+		sender.setRole(senderRole);
+
+		frame.setSender(sender);
+
+		SemanticProtocol semanticProtocol = new SemanticProtocol();
+
+		List<SemanticProtocolEntry> list = new ArrayList<>();
+		SemanticProtocolEntry valuedIdentification = new SemanticProtocolEntry();
+
+		valuedIdentification.setType("GLOBAL_REFERENCE");
+		valuedIdentification.setIdType("CUSTOM");
+		valuedIdentification.setValue("TEST_PROTOCOL");
+
+		list.add(valuedIdentification);
+		semanticProtocol.setKeys(list);
+
+		frame.setSemanticProtocol(semanticProtocol);
+		frame.setType("TEST_MESSAGE");
+
+		return frame;
+	}
 }

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/MessageHelper.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/MessageHelper.java
@@ -1,0 +1,2 @@
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0;public class MessageHelper {
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/TestMinimumViableActiveAas.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/TestMinimumViableActiveAas.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0;
+
+import io.moquette.broker.Server;
+import io.moquette.broker.config.ClasspathResourceLoader;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.IResourceLoader;
+import io.moquette.broker.config.ResourceLoaderConfig;
+import org.eclipse.basyx.aas.factory.json.JSONToMetamodelConverter;
+import org.eclipse.basyx.extensions.i4dot0.mqtt.Databus;
+import org.eclipse.basyx.submodel.metamodel.map.Submodel;
+import org.eclipse.basyx.submodel.metamodel.map.submodelelement.SubmodelElementCollection;
+import org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback.GenericMqttCallback;
+import org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback.SmcMqttCallback;
+import org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback.SubmodelMqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test of the I4.0-Extension. Represents minimum viable setup for each {@link org.eclipse.basyx.extensions.i4dot0.domain.Message} type. Shows example message handling and validates the received data.
+ *
+ * @author wand
+ */
+public class TestMinimumViableActiveAas {
+
+	private static Server mqttBroker;
+	private static GenericMqttCallback genericMqttCallback;
+	private static SubmodelMqttCallback submodelMqttCallback;
+	private static SmcMqttCallback smcMqttCallback;
+	private static List<Submodel> submodelList;
+
+	@BeforeClass
+	public static void setup() throws IOException, InterruptedException {
+		mqttBroker = new Server();
+		IResourceLoader classpathLoader = new ClasspathResourceLoader();
+		final IConfig classPathConfig = new ResourceLoaderConfig(classpathLoader);
+		mqttBroker.startServer(classPathConfig);
+
+		String jsonPath = "src/test/resources/aas/factory/json/aasJsonSchemaV2.0.1_Example.json";
+		String json = new String(Files.readAllBytes(Paths.get(jsonPath)));
+		JSONToMetamodelConverter converter = new JSONToMetamodelConverter(json);
+		submodelList = converter.parseSubmodels();
+
+		Databus genericDatabus = new Databus();
+		MqttClient genericMqttClient = genericDatabus.init("tcp://localhost:1884", "basyx_test/generic_topic", "basyx_test/generic_topic", null, null);
+		genericMqttCallback = new GenericMqttCallback();
+		genericMqttClient.setCallback(genericMqttCallback);
+
+		Databus submodelDatabus = new Databus();
+		MqttClient submodelMqttClient = submodelDatabus.init("tcp://localhost:1884", "basyx_test/submodel_topic", "basyx_test/submodel_topic", null, null);
+		submodelMqttCallback = new SubmodelMqttCallback();
+		submodelMqttClient.setCallback(submodelMqttCallback);
+
+		Databus smcDatabus = new Databus();
+		MqttClient smcMqttClient = smcDatabus.init("tcp://localhost:1884", "basyx_test/smc_topic", "basyx_test/smc_topic", null, null);
+		smcMqttCallback = new SmcMqttCallback();
+		smcMqttClient.setCallback(smcMqttCallback);
+
+		MessageHelper messageHelper = new MessageHelper(submodelList);
+		genericDatabus.publish(messageHelper.generateGenericMessage());
+		submodelDatabus.publish(messageHelper.generateSubmodelMessage());
+		smcDatabus.publish(messageHelper.generateSubmodelElementCollectionMessage());
+
+		//this sleep ensures that all messages are received
+		Thread.sleep(500);
+	}
+
+	@AfterClass
+	public static void stopMqttBroker() {
+		if (mqttBroker == null) {
+			return;
+		}
+		mqttBroker.stopServer();
+	}
+
+	@Test
+	public void checkMessages() {
+		Map<String, Object> interactionElements = new HashMap<>();
+		interactionElements.put("interactionElement1", "Bob");
+		interactionElements.put("interactionElement2", "Eve");
+		assertEquals(genericMqttCallback.getMostRecentMessage().getInteractionElements(), List.of(interactionElements));
+
+		Submodel receivedSubmodel = submodelMqttCallback.getMostRecentMessage().getInteractionElements().get(0);
+		submodelList.get(0).forEach((key, value) -> assertEquals(receivedSubmodel.get(key), value));
+
+		SubmodelElementCollection receivedSmc = smcMqttCallback.getMostRecentMessage().getInteractionElements().get(0);
+		((SubmodelElementCollection) submodelList.get(1).getSubmodelElement("OperatingManual")).forEach((key, value) -> assertEquals(receivedSmc.get(key), value));
+	}
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/GenericMqttCallback.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/GenericMqttCallback.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.GenericMessage;
+import org.eclipse.basyx.extensions.i4dot0.mqtt.CallbackExtender;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.io.IOException;
+
+/**
+ * Callback to handle an incoming {@link GenericMessage}.
+ *
+ * @author wand
+ */
+public class GenericMqttCallback implements CallbackExtender {
+
+	private GenericMessage message;
+
+	@Override
+	public void messageArrived(String s, MqttMessage mqttMessage) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			message = mapper.readValue(mqttMessage.getPayload(), GenericMessage.class);
+		} catch (IOException e) {
+			logger.error("Unable to parse GenericMessage");
+		}
+	}
+
+	public GenericMessage getMostRecentMessage() {
+		return message;
+	}
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/SmcMqttCallback.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/SmcMqttCallback.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.SubmodelElementCollectionMessage;
+import org.eclipse.basyx.extensions.i4dot0.mqtt.CallbackExtender;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.io.IOException;
+
+/**
+ * Callback to handle an incoming {@link SubmodelElementCollectionMessage}.
+ *
+ * @author wand
+ */
+public class SmcMqttCallback implements CallbackExtender {
+
+	private SubmodelElementCollectionMessage message;
+
+	@Override
+	public void messageArrived(String s, MqttMessage mqttMessage) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			message = mapper.readValue(mqttMessage.getPayload(), SubmodelElementCollectionMessage.class);
+		} catch (IOException e) {
+			logger.error("Unable to parse SmcMqttCallback");
+		}
+	}
+
+	public SubmodelElementCollectionMessage getMostRecentMessage() {
+		return message;
+	}
+}

--- a/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/SubmodelMqttCallback.java
+++ b/src/test/java/org/eclipse/basyx/testsuite/regression/extensions/i4dot0/callback/SubmodelMqttCallback.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (C) 2024 the Eclipse BaSyx Authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+package org.eclipse.basyx.testsuite.regression.extensions.i4dot0.callback;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.basyx.extensions.i4dot0.domain.message.SubmodelMessage;
+import org.eclipse.basyx.extensions.i4dot0.mqtt.CallbackExtender;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.io.IOException;
+
+/**
+ * Callback to handle an incoming {@link SubmodelMessage}.
+ *
+ * @author wand
+ */
+public class SubmodelMqttCallback implements CallbackExtender {
+
+	private SubmodelMessage message;
+
+	@Override
+	public void messageArrived(String s, MqttMessage mqttMessage) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			message = mapper.readValue(mqttMessage.getPayload(), SubmodelMessage.class);
+
+		} catch (IOException e) {
+			logger.error("Unable to parse SubmodelMessage");
+		}
+	}
+
+	public SubmodelMessage getMostRecentMessage() {
+		return message;
+	}
+}


### PR DESCRIPTION
As part of the R&D project BaSys4IPPS, an active asset administration shell was created based on the this SDK. The active AAS uses the VDI/VDE 2193 standardized I4.0 language for communication. This communication is carried out via a MQTT broker. The extension published here includes classes to enable the aforementioned communication.
It is possible to establish a connection to a MQTT broker, send and receive I4.0 messages. The so-called I4.0 extension additionally contains classes to create a Java object of an I4.0 message.
An I4.0 message consists of a frame and interactionElements. The interactionElements represent the content of the message. The content can either be a list of AAS submodels or a list of key-value pairs. This is represented by the abstract superclass "Message" through subclasses SubmodelMessage and GenericMessage.
This extension allows an active AAS to be implemented, as well as to send and receive standardized messages.